### PR TITLE
Polybench 4.2 and Dataset sizes

### DIFF
--- a/benchmarks/Polybench/4.2/2mm/2mm.c
+++ b/benchmarks/Polybench/4.2/2mm/2mm.c
@@ -1,0 +1,167 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* 2mm.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "2mm.h"
+
+
+/* Array initialization. */
+static
+void init_array(int ni, int nj, int nk, int nl,
+                DATA_TYPE *alpha,
+                DATA_TYPE *beta,
+                DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk),
+                DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj),
+                DATA_TYPE POLYBENCH_2D(C, NJ, NL, nj, nl),
+                DATA_TYPE POLYBENCH_2D(D, NI, NL, ni, nl))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nk; j++)
+            A[i][j] = (DATA_TYPE) ((i * j + 1) % ni) / ni;
+    for (i = 0; i < nk; i++)
+        for (j = 0; j < nj; j++)
+            B[i][j] = (DATA_TYPE) (i * (j + 1) % nj) / nj;
+    for (i = 0; i < nj; i++)
+        for (j = 0; j < nl; j++)
+            C[i][j] = (DATA_TYPE) ((i * (j + 3) + 1) % nl) / nl;
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nl; j++)
+            D[i][j] = (DATA_TYPE) (i * (j + 2) % nk) / nk;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int ni, int nl,
+                 DATA_TYPE POLYBENCH_2D(D, NI, NL, ni, nl))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("D");
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nl; j++)
+        {
+            if ((i * ni + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, D[i][j]);
+        }
+    POLYBENCH_DUMP_END("D");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_2mm(int ni, int nj, int nk, int nl,
+                DATA_TYPE alpha,
+                DATA_TYPE beta,
+                DATA_TYPE POLYBENCH_2D(tmp, NI, NJ, ni, nj),
+                DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk),
+                DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj),
+                DATA_TYPE POLYBENCH_2D(C, NJ, NL, nj, nl),
+                DATA_TYPE POLYBENCH_2D(D, NI, NL, ni, nl))
+{
+    int i, j, k;
+
+
+    for (i = 0; i < _PB_NI; i++)
+    {
+        for (j = 0; j < _PB_NJ; j++)
+        {
+            tmp[i][j] = SCALAR_VAL(0.0);
+            for (k = 0; k < _PB_NK; ++k)
+                tmp[i][j] += alpha * A[i][k] * B[k][j];
+        }
+    }
+
+
+    for (i = 0; i < _PB_NI; i++)
+    {
+        for (j = 0; j < _PB_NL; j++)
+        {
+            D[i][j] *= beta;
+            for (k = 0; k < _PB_NJ; ++k)
+                D[i][j] += tmp[i][k] * C[k][j];
+
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int ni = NI;
+    int nj = NJ;
+    int nk = NK;
+    int nl = NL;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(tmp, DATA_TYPE, NI, NJ, ni, nj);
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, NI, NK, ni, nk);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, NK, NJ, nk, nj);
+    POLYBENCH_2D_ARRAY_DECL(C, DATA_TYPE, NJ, NL, nj, nl);
+    POLYBENCH_2D_ARRAY_DECL(D, DATA_TYPE, NI, NL, ni, nl);
+
+    /* Initialize array(s). */
+    init_array (ni, nj, nk, nl, &alpha, &beta,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B),
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(D));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_2mm (ni, nj, nk, nl,
+                alpha, beta,
+                POLYBENCH_ARRAY(tmp),
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B),
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(D));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(ni, nl,  POLYBENCH_ARRAY(D)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(tmp);
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+    POLYBENCH_FREE_ARRAY(C);
+    POLYBENCH_FREE_ARRAY(D);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/2mm/2mm.h
+++ b/benchmarks/Polybench/4.2/2mm/2mm.h
@@ -1,0 +1,92 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _2MM_H
+# define _2MM_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(NI) && !defined(NJ) && !defined(NK) && !defined(NL)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define NI 16
+#   define NJ 18
+#   define NK 22
+#   define NL 24
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define NI 40
+#   define NJ 50
+#   define NK 70
+#   define NL 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define NI 180
+#   define NJ 190
+#   define NK 210
+#   define NL 220
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define NI 800
+#   define NJ 900
+#   define NK 1100
+#   define NL 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define NI 1600
+#   define NJ 1800
+#   define NK 2200
+#   define NL 2400
+#  endif
+
+
+#endif /* !(NI NJ NK NL) */
+
+# define _PB_NI POLYBENCH_LOOP_BOUND(NI,ni)
+# define _PB_NJ POLYBENCH_LOOP_BOUND(NJ,nj)
+# define _PB_NK POLYBENCH_LOOP_BOUND(NK,nk)
+# define _PB_NL POLYBENCH_LOOP_BOUND(NL,nl)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_2MM_H */

--- a/benchmarks/Polybench/4.2/2mm/2mm.h
+++ b/benchmarks/Polybench/4.2/2mm/2mm.h
@@ -62,13 +62,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/3mm/3mm.c
+++ b/benchmarks/Polybench/4.2/3mm/3mm.c
@@ -1,0 +1,177 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* 3mm.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "3mm.h"
+
+
+/* Array initialization. */
+static
+void init_array(int ni, int nj, int nk, int nl, int nm,
+                DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk),
+                DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj),
+                DATA_TYPE POLYBENCH_2D(C, NJ, NM, nj, nm),
+                DATA_TYPE POLYBENCH_2D(D, NM, NL, nm, nl))
+{
+    int i, j;
+
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nk; j++)
+            A[i][j] = (DATA_TYPE) ((i * j + 1) % ni) / (5 * ni);
+    for (i = 0; i < nk; i++)
+        for (j = 0; j < nj; j++)
+            B[i][j] = (DATA_TYPE) ((i * (j + 1) + 2) % nj) / (5 * nj);
+    for (i = 0; i < nj; i++)
+        for (j = 0; j < nm; j++)
+            C[i][j] = (DATA_TYPE) (i * (j + 3) % nl) / (5 * nl);
+    for (i = 0; i < nm; i++)
+        for (j = 0; j < nl; j++)
+            D[i][j] = (DATA_TYPE) ((i * (j + 2) + 2) % nk) / (5 * nk);
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int ni, int nl,
+                 DATA_TYPE POLYBENCH_2D(G, NI, NL, ni, nl))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("G");
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nl; j++)
+        {
+            if ((i * ni + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, G[i][j]);
+        }
+    POLYBENCH_DUMP_END("G");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_3mm(int ni, int nj, int nk, int nl, int nm,
+                DATA_TYPE POLYBENCH_2D(E, NI, NJ, ni, nj),
+                DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk),
+                DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj),
+                DATA_TYPE POLYBENCH_2D(F, NJ, NL, nj, nl),
+                DATA_TYPE POLYBENCH_2D(C, NJ, NM, nj, nm),
+                DATA_TYPE POLYBENCH_2D(D, NM, NL, nm, nl),
+                DATA_TYPE POLYBENCH_2D(G, NI, NL, ni, nl))
+{
+    int i, j, k;
+
+
+    for (i = 0; i < _PB_NI; i++)
+    {
+        for (j = 0; j < _PB_NJ; j++)
+        {
+            E[i][j] = SCALAR_VAL(0.0);
+            for (k = 0; k < _PB_NK; ++k)
+                E[i][j] += A[i][k] * B[k][j];
+        }
+    }
+
+
+    for (i = 0; i < _PB_NJ; i++)
+    {
+        for (j = 0; j < _PB_NL; j++)
+        {
+            F[i][j] = SCALAR_VAL(0.0);
+            for (k = 0; k < _PB_NM; ++k)
+                F[i][j] += C[i][k] * D[k][j];
+        }
+    }
+
+
+    for (i = 0; i < _PB_NI; i++)
+    {
+        for (j = 0; j < _PB_NL; j++)
+        {
+            G[i][j] = SCALAR_VAL(0.0);
+            for (k = 0; k < _PB_NJ; ++k)
+                G[i][j] += E[i][k] * F[k][j];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int ni = NI;
+    int nj = NJ;
+    int nk = NK;
+    int nl = NL;
+    int nm = NM;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(E, DATA_TYPE, NI, NJ, ni, nj);
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, NI, NK, ni, nk);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, NK, NJ, nk, nj);
+    POLYBENCH_2D_ARRAY_DECL(F, DATA_TYPE, NJ, NL, nj, nl);
+    POLYBENCH_2D_ARRAY_DECL(C, DATA_TYPE, NJ, NM, nj, nm);
+    POLYBENCH_2D_ARRAY_DECL(D, DATA_TYPE, NM, NL, nm, nl);
+    POLYBENCH_2D_ARRAY_DECL(G, DATA_TYPE, NI, NL, ni, nl);
+
+    /* Initialize array(s). */
+    init_array (ni, nj, nk, nl, nm,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B),
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(D));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_3mm (ni, nj, nk, nl, nm,
+                POLYBENCH_ARRAY(E),
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B),
+                POLYBENCH_ARRAY(F),
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(D),
+                POLYBENCH_ARRAY(G));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(ni, nl,  POLYBENCH_ARRAY(G)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(E);
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+    POLYBENCH_FREE_ARRAY(F);
+    POLYBENCH_FREE_ARRAY(C);
+    POLYBENCH_FREE_ARRAY(D);
+    POLYBENCH_FREE_ARRAY(G);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/3mm/3mm.h
+++ b/benchmarks/Polybench/4.2/3mm/3mm.h
@@ -1,0 +1,98 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _3MM_H
+# define _3MM_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(NI) && !defined(NJ) && !defined(NK) && !defined(NL) && !defined(NM)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define NI 16
+#   define NJ 18
+#   define NK 20
+#   define NL 22
+#   define NM 24
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define NI 40
+#   define NJ 50
+#   define NK 60
+#   define NL 70
+#   define NM 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define NI 180
+#   define NJ 190
+#   define NK 200
+#   define NL 210
+#   define NM 220
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define NI 800
+#   define NJ 900
+#   define NK 1000
+#   define NL 1100
+#   define NM 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define NI 1600
+#   define NJ 1800
+#   define NK 2000
+#   define NL 2200
+#   define NM 2400
+#  endif
+
+
+#endif /* !(NI NJ NK NL NM) */
+
+# define _PB_NI POLYBENCH_LOOP_BOUND(NI,ni)
+# define _PB_NJ POLYBENCH_LOOP_BOUND(NJ,nj)
+# define _PB_NK POLYBENCH_LOOP_BOUND(NK,nk)
+# define _PB_NL POLYBENCH_LOOP_BOUND(NL,nl)
+# define _PB_NM POLYBENCH_LOOP_BOUND(NM,nm)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_3MM_H */

--- a/benchmarks/Polybench/4.2/3mm/3mm.h
+++ b/benchmarks/Polybench/4.2/3mm/3mm.h
@@ -68,13 +68,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/adi/adi.c
+++ b/benchmarks/Polybench/4.2/adi/adi.c
@@ -1,0 +1,175 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* adi.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "adi.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_2D(u, N, N, n, n))
+{
+    int i, j;
+
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            u[i][j] =  (DATA_TYPE)(i + n - j) / n;
+        }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(u, N, N, n, n))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("u");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf(POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, u[i][j]);
+        }
+    POLYBENCH_DUMP_END("u");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+/* Based on a Fortran code fragment from Figure 5 of
+ * "Automatic Data and Computation Decomposition on Distributed Memory Parallel Computers"
+ * by Peizong Lee and Zvi Meir Kedem, TOPLAS, 2002
+ */
+static
+void kernel_adi(int tsteps, int n,
+                DATA_TYPE POLYBENCH_2D(u, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(v, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(p, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(q, N, N, n, n))
+{
+    int t, i, j;
+    DATA_TYPE DX, DY, DT;
+    DATA_TYPE B1, B2;
+    DATA_TYPE mul1, mul2;
+    DATA_TYPE a, b, c, d, e, f;
+
+
+
+    DX = SCALAR_VAL(1.0) / (DATA_TYPE)_PB_N;
+    DY = SCALAR_VAL(1.0) / (DATA_TYPE)_PB_N;
+    DT = SCALAR_VAL(1.0) / (DATA_TYPE)_PB_TSTEPS;
+    B1 = SCALAR_VAL(2.0);
+    B2 = SCALAR_VAL(1.0);
+    mul1 = B1 * DT / (DX * DX);
+    mul2 = B2 * DT / (DY * DY);
+
+    a = -mul1 /  SCALAR_VAL(2.0);
+    b = SCALAR_VAL(1.0) + mul1;
+    c = a;
+    d = -mul2 / SCALAR_VAL(2.0);
+    e = SCALAR_VAL(1.0) + mul2;
+    f = d;
+
+    for (t = 1; t <= _PB_TSTEPS; t++)
+    {
+        for (i = 1; i < _PB_N - 1; i++)
+        {
+            v[0][i] = SCALAR_VAL(1.0);
+            p[i][0] = SCALAR_VAL(0.0);
+            q[i][0] = v[0][i];
+            for (j = 1; j < _PB_N - 1; j++)
+            {
+                p[i][j] = -c / (a * p[i][j - 1] + b);
+                q[i][j] = (-d * u[j][i - 1] + (SCALAR_VAL(1.0) + SCALAR_VAL(2.0) * d) * u[j][i] - f * u[j][i + 1] - a * q[i][j - 1]) / (a * p[i][j - 1] + b);
+            }
+
+            v[_PB_N - 1][i] = SCALAR_VAL(1.0);
+            for (j = _PB_N - 2; j >= 1; j--)
+            {
+                v[j][i] = p[i][j] * v[j + 1][i] + q[i][j];
+            }
+        }
+
+        for (i = 1; i < _PB_N - 1; i++)
+        {
+            u[i][0] = SCALAR_VAL(1.0);
+            p[i][0] = SCALAR_VAL(0.0);
+            q[i][0] = u[i][0];
+            for (j = 1; j < _PB_N - 1; j++)
+            {
+                p[i][j] = -f / (d * p[i][j - 1] + e);
+                q[i][j] = (-a * v[i - 1][j] + (SCALAR_VAL(1.0) + SCALAR_VAL(2.0) * a) * v[i][j] - c * v[i + 1][j] - d * q[i][j - 1]) / (d * p[i][j - 1] + e);
+            }
+            u[i][_PB_N - 1] = SCALAR_VAL(1.0);
+            for (j = _PB_N - 2; j >= 1; j--)
+            {
+                u[i][j] = p[i][j] * u[i][j + 1] + q[i][j];
+            }
+        }
+    }
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int tsteps = TSTEPS;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(u, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(v, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(p, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(q, DATA_TYPE, N, N, n, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(u));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_adi (tsteps, n, POLYBENCH_ARRAY(u), POLYBENCH_ARRAY(v), POLYBENCH_ARRAY(p), POLYBENCH_ARRAY(q));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(u)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(u);
+    POLYBENCH_FREE_ARRAY(v);
+    POLYBENCH_FREE_ARRAY(p);
+    POLYBENCH_FREE_ARRAY(q);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/adi/adi.h
+++ b/benchmarks/Polybench/4.2/adi/adi.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _ADI_H
+# define _ADI_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(TSTEPS) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define TSTEPS 20
+#   define N 20
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define TSTEPS 40
+#   define N 60
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define TSTEPS 100
+#   define N 200
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define TSTEPS 500
+#   define N 1000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define TSTEPS 1000
+#   define N 2000
+#  endif
+
+
+#endif /* !(TSTEPS N) */
+
+# define _PB_TSTEPS POLYBENCH_LOOP_BOUND(TSTEPS,tsteps)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_ADI_H */

--- a/benchmarks/Polybench/4.2/adi/adi.h
+++ b/benchmarks/Polybench/4.2/adi/adi.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/atax/atax.c
+++ b/benchmarks/Polybench/4.2/atax/atax.c
@@ -1,0 +1,132 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* atax.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "atax.h"
+
+
+/* Array initialization. */
+static
+void init_array (int m, int n,
+                 DATA_TYPE POLYBENCH_2D(A, M, N, m, n),
+                 DATA_TYPE POLYBENCH_1D(x, N, n))
+{
+    int i, j;
+    DATA_TYPE fn;
+    fn = (DATA_TYPE)n;
+
+    for (i = 0; i < n; i++)
+        x[i] = 1 + (i / fn);
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+            A[i][j] = (DATA_TYPE) ((i + j) % n) / (5 * m);
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(y, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("y");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, y[i]);
+    }
+    POLYBENCH_DUMP_END("y");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_atax(int m, int n,
+                 DATA_TYPE POLYBENCH_2D(A, M, N, m, n),
+                 DATA_TYPE POLYBENCH_1D(x, N, n),
+                 DATA_TYPE POLYBENCH_1D(y, N, n),
+                 DATA_TYPE POLYBENCH_1D(tmp, M, m))
+{
+    int i, j;
+
+
+    for (i = 0; i < _PB_N; i++)
+        y[i] = 0;
+
+    for (i = 0; i < _PB_M; i++)
+    {
+        tmp[i] = SCALAR_VAL(0.0);
+        for (j = 0; j < _PB_N; j++)
+            tmp[i] = tmp[i] + A[i][j] * x[j];
+
+        for (j = 0; j < _PB_N; j++)
+            y[j] = y[j] + A[i][j] * tmp[i];
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int m = M;
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, M, N, m, n);
+    POLYBENCH_1D_ARRAY_DECL(x, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(tmp, DATA_TYPE, M, m);
+
+    /* Initialize array(s). */
+    init_array (m, n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(x));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_atax (m, n,
+                 POLYBENCH_ARRAY(A),
+                 POLYBENCH_ARRAY(x),
+                 POLYBENCH_ARRAY(y),
+                 POLYBENCH_ARRAY(tmp));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(y)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(x);
+    POLYBENCH_FREE_ARRAY(y);
+    POLYBENCH_FREE_ARRAY(tmp);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/atax/atax.h
+++ b/benchmarks/Polybench/4.2/atax/atax.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _ATAX_H
+# define _ATAX_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 38
+#   define N 42
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 116
+#   define N 124
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 390
+#   define N 410
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1900
+#   define N 2100
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 1800
+#   define N 2200
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_ATAX_H */

--- a/benchmarks/Polybench/4.2/atax/atax.h
+++ b/benchmarks/Polybench/4.2/atax/atax.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/bicg/bicg.c
+++ b/benchmarks/Polybench/4.2/bicg/bicg.c
@@ -1,0 +1,149 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* bicg.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "bicg.h"
+
+
+/* Array initialization. */
+static
+void init_array (int m, int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, M, n, m),
+                 DATA_TYPE POLYBENCH_1D(r, N, n),
+                 DATA_TYPE POLYBENCH_1D(p, M, m))
+{
+    int i, j;
+
+    for (i = 0; i < m; i++)
+        p[i] = (DATA_TYPE)(i % m) / m;
+    for (i = 0; i < n; i++)
+    {
+        r[i] = (DATA_TYPE)(i % n) / n;
+        for (j = 0; j < m; j++)
+            A[i][j] = (DATA_TYPE) (i * (j + 1) % n) / n;
+    }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int m, int n,
+                 DATA_TYPE POLYBENCH_1D(s, M, m),
+                 DATA_TYPE POLYBENCH_1D(q, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("s");
+    for (i = 0; i < m; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, s[i]);
+    }
+    POLYBENCH_DUMP_END("s");
+    POLYBENCH_DUMP_BEGIN("q");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, q[i]);
+    }
+    POLYBENCH_DUMP_END("q");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_bicg(int m, int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, M, n, m),
+                 DATA_TYPE POLYBENCH_1D(s, M, m),
+                 DATA_TYPE POLYBENCH_1D(q, N, n),
+                 DATA_TYPE POLYBENCH_1D(p, M, m),
+                 DATA_TYPE POLYBENCH_1D(r, N, n))
+{
+    int i, j;
+
+
+    for (i = 0; i < _PB_M; i++)
+        s[i] = 0;
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        q[i] = SCALAR_VAL(0.0);
+        for (j = 0; j < _PB_M; j++)
+        {
+            s[j] = s[j] + r[i] * A[i][j];
+            q[i] = q[i] + A[i][j] * p[j];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int m = M;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, M, n, m);
+    POLYBENCH_1D_ARRAY_DECL(s, DATA_TYPE, M, m);
+    POLYBENCH_1D_ARRAY_DECL(q, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(p, DATA_TYPE, M, m);
+    POLYBENCH_1D_ARRAY_DECL(r, DATA_TYPE, N, n);
+
+    /* Initialize array(s). */
+    init_array (m, n,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(r),
+                POLYBENCH_ARRAY(p));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_bicg (m, n,
+                 POLYBENCH_ARRAY(A),
+                 POLYBENCH_ARRAY(s),
+                 POLYBENCH_ARRAY(q),
+                 POLYBENCH_ARRAY(p),
+                 POLYBENCH_ARRAY(r));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(m, n, POLYBENCH_ARRAY(s), POLYBENCH_ARRAY(q)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(s);
+    POLYBENCH_FREE_ARRAY(q);
+    POLYBENCH_FREE_ARRAY(p);
+    POLYBENCH_FREE_ARRAY(r);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/bicg/bicg.h
+++ b/benchmarks/Polybench/4.2/bicg/bicg.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _BICG_H
+# define _BICG_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 38
+#   define N 42
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 116
+#   define N 124
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 390
+#   define N 410
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1900
+#   define N 2100
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 1800
+#   define N 2200
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_BICG_H */

--- a/benchmarks/Polybench/4.2/bicg/bicg.h
+++ b/benchmarks/Polybench/4.2/bicg/bicg.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/cholesky/cholesky.c
+++ b/benchmarks/Polybench/4.2/cholesky/cholesky.c
@@ -1,0 +1,145 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* cholesky.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "cholesky.h"
+
+
+/* Array initialization. */
+static
+void init_array(int n,
+                DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+  int i, j;
+
+  for (i = 0; i < n; i++)
+  {
+    for (j = 0; j <= i; j++)
+      A[i][j] = (DATA_TYPE)(-j % n) / n + 1;
+    for (j = i + 1; j < n; j++)
+    {
+      A[i][j] = 0;
+    }
+    A[i][i] = 1;
+  }
+
+  /* Make the matrix positive semi-definite. */
+  int r, s, t;
+  POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, N, N, n, n);
+  for (r = 0; r < n; ++r)
+    for (s = 0; s < n; ++s)
+      (POLYBENCH_ARRAY(B))[r][s] = 0;
+  for (t = 0; t < n; ++t)
+    for (r = 0; r < n; ++r)
+      for (s = 0; s < n; ++s)
+        (POLYBENCH_ARRAY(B))[r][s] += A[r][t] * A[s][t];
+  for (r = 0; r < n; ++r)
+    for (s = 0; s < n; ++s)
+      A[r][s] = (POLYBENCH_ARRAY(B))[r][s];
+  POLYBENCH_FREE_ARRAY(B);
+
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+
+{
+  int i, j;
+
+  POLYBENCH_DUMP_START;
+  POLYBENCH_DUMP_BEGIN("A");
+  for (i = 0; i < n; i++)
+    for (j = 0; j <= i; j++)
+    {
+      if ((i * n + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+      fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i][j]);
+    }
+  POLYBENCH_DUMP_END("A");
+  POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_cholesky(int n,
+                     DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+  int i, j, k;
+
+
+
+  for (i = 0; i < _PB_N; i++)
+  {
+    //j<i
+    for (j = 0; j < i; j++)
+    {
+
+      for (k = 0; k < j; k++)
+      {
+        A[i][j] -= A[i][k] * A[j][k];
+      }
+      A[i][j] /= A[j][j];
+    }
+    // i==j case
+    for (k = 0; k < i; k++)
+    {
+      A[i][i] -= A[i][k] * A[i][k];
+    }
+    A[i][i] = SQRT_FUN(A[i][i]);
+  }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+  /* Retrieve problem size. */
+  int n = N;
+
+  /* Variable declaration/allocation. */
+  POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+
+  /* Initialize array(s). */
+  init_array (n, POLYBENCH_ARRAY(A));
+
+  /* Start timer. */
+  polybench_start_instruments;
+
+  /* Run kernel. */
+  kernel_cholesky (n, POLYBENCH_ARRAY(A));
+
+  /* Stop and print timer. */
+  polybench_stop_instruments;
+  polybench_print_instruments;
+
+  /* Prevent dead-code elimination. All live-out data must be printed
+     by the function call in argument. */
+  polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(A)));
+
+  /* Be clean. */
+  POLYBENCH_FREE_ARRAY(A);
+
+  return 0;
+}

--- a/benchmarks/Polybench/4.2/cholesky/cholesky.h
+++ b/benchmarks/Polybench/4.2/cholesky/cholesky.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _CHOLESKY_H
+# define _CHOLESKY_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_CHOLESKY_H */

--- a/benchmarks/Polybench/4.2/cholesky/cholesky.h
+++ b/benchmarks/Polybench/4.2/cholesky/cholesky.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/correlation/correlation.c
+++ b/benchmarks/Polybench/4.2/correlation/correlation.c
@@ -1,0 +1,166 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* correlation.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "correlation.h"
+
+
+/* Array initialization. */
+static
+void init_array (int m,
+                 int n,
+                 DATA_TYPE *float_n,
+                 DATA_TYPE POLYBENCH_2D(data, N, M, n, m))
+{
+    int i, j;
+
+    *float_n = (DATA_TYPE)N;
+
+    for (i = 0; i < N; i++)
+        for (j = 0; j < M; j++)
+            data[i][j] = (DATA_TYPE)(i * j) / M + i;
+
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int m,
+                 DATA_TYPE POLYBENCH_2D(corr, M, M, m, m))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("corr");
+    for (i = 0; i < m; i++)
+        for (j = 0; j < m; j++)
+        {
+            if ((i * m + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, corr[i][j]);
+        }
+    POLYBENCH_DUMP_END("corr");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_correlation(int m, int n,
+                        DATA_TYPE float_n,
+                        DATA_TYPE POLYBENCH_2D(data, N, M, n, m),
+                        DATA_TYPE POLYBENCH_2D(corr, M, M, m, m),
+                        DATA_TYPE POLYBENCH_1D(mean, M, m),
+                        DATA_TYPE POLYBENCH_1D(stddev, M, m))
+{
+    int i, j, k;
+
+    DATA_TYPE eps = SCALAR_VAL(0.1);
+
+
+
+    for (j = 0; j < _PB_M; j++)
+    {
+        mean[j] = SCALAR_VAL(0.0);
+        for (i = 0; i < _PB_N; i++)
+            mean[j] += data[i][j];
+        mean[j] /= float_n;
+    }
+
+    for (j = 0; j < _PB_M; j++)
+    {
+        stddev[j] = SCALAR_VAL(0.0);
+        for (i = 0; i < _PB_N; i++)
+            stddev[j] += (data[i][j] - mean[j]) * (data[i][j] - mean[j]);
+        stddev[j] /= float_n;
+        stddev[j] = SQRT_FUN(stddev[j]);
+        stddev[j] = stddev[j] <= eps ? SCALAR_VAL(1.0) : stddev[j];
+    }
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_M; j++)
+        {
+            data[i][j] -= mean[j];
+            data[i][j] /= SQRT_FUN(float_n) * stddev[j];
+        }
+    }
+
+    for (i = 0; i < _PB_M - 1; i++)
+    {
+        corr[i][i] = SCALAR_VAL(1.0);
+        for (j = i + 1; j < _PB_M; j++)
+        {
+            corr[i][j] = SCALAR_VAL(0.0);
+            for (k = 0; k < _PB_N; k++)
+                corr[i][j] += (data[k][i] * data[k][j]);
+            corr[j][i] = corr[i][j];
+        }
+    }
+    corr[_PB_M - 1][_PB_M - 1] = SCALAR_VAL(1.0);
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int m = M;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE float_n;
+    POLYBENCH_2D_ARRAY_DECL(data, DATA_TYPE, N, M, n, m);
+    POLYBENCH_2D_ARRAY_DECL(corr, DATA_TYPE, M, M, m, m);
+    POLYBENCH_1D_ARRAY_DECL(mean, DATA_TYPE, M, m);
+    POLYBENCH_1D_ARRAY_DECL(stddev, DATA_TYPE, M, m);
+
+    /* Initialize array(s). */
+    init_array (m, n, &float_n, POLYBENCH_ARRAY(data));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_correlation (m, n, float_n,
+                        POLYBENCH_ARRAY(data),
+                        POLYBENCH_ARRAY(corr),
+                        POLYBENCH_ARRAY(mean),
+                        POLYBENCH_ARRAY(stddev));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(m, POLYBENCH_ARRAY(corr)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(data);
+    POLYBENCH_FREE_ARRAY(corr);
+    POLYBENCH_FREE_ARRAY(mean);
+    POLYBENCH_FREE_ARRAY(stddev);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/correlation/correlation.h
+++ b/benchmarks/Polybench/4.2/correlation/correlation.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _CORRELATION_H
+# define _CORRELATION_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 28
+#   define N 32
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 80
+#   define N 100
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 240
+#   define N 260
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1200
+#   define N 1400
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2600
+#   define N 3000
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_CORRELATION_H */

--- a/benchmarks/Polybench/4.2/correlation/correlation.h
+++ b/benchmarks/Polybench/4.2/correlation/correlation.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/covariance/covariance.c
+++ b/benchmarks/Polybench/4.2/covariance/covariance.c
@@ -1,0 +1,144 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* covariance.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "covariance.h"
+
+
+/* Array initialization. */
+static
+void init_array (int m, int n,
+                 DATA_TYPE *float_n,
+                 DATA_TYPE POLYBENCH_2D(data, N, M, n, m))
+{
+    int i, j;
+
+    *float_n = (DATA_TYPE)n;
+
+    for (i = 0; i < N; i++)
+        for (j = 0; j < M; j++)
+            data[i][j] = ((DATA_TYPE) i * j) / M;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int m,
+                 DATA_TYPE POLYBENCH_2D(cov, M, M, m, m))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("cov");
+    for (i = 0; i < m; i++)
+        for (j = 0; j < m; j++)
+        {
+            if ((i * m + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, cov[i][j]);
+        }
+    POLYBENCH_DUMP_END("cov");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_covariance(int m, int n,
+                       DATA_TYPE float_n,
+                       DATA_TYPE POLYBENCH_2D(data, N, M, n, m),
+                       DATA_TYPE POLYBENCH_2D(cov, M, M, m, m),
+                       DATA_TYPE POLYBENCH_1D(mean, M, m))
+{
+    int i, j, k;
+
+
+    for (j = 0; j < _PB_M; j++)
+    {
+        mean[j] = SCALAR_VAL(0.0);
+        for (i = 0; i < _PB_N; i++)
+            mean[j] += data[i][j];
+        mean[j] /= float_n;
+    }
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_M; j++)
+            data[i][j] -= mean[j];
+    }
+
+    for (i = 0; i < _PB_M; i++)
+    {
+        for (j = i; j < _PB_M; j++)
+        {
+            cov[i][j] = SCALAR_VAL(0.0);
+            for (k = 0; k < _PB_N; k++)
+                cov[i][j] += data[k][i] * data[k][j];
+            cov[i][j] /= (float_n - SCALAR_VAL(1.0));
+            cov[j][i] = cov[i][j];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int m = M;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE float_n;
+    POLYBENCH_2D_ARRAY_DECL(data, DATA_TYPE, N, M, n, m);
+    POLYBENCH_2D_ARRAY_DECL(cov, DATA_TYPE, M, M, m, m);
+    POLYBENCH_1D_ARRAY_DECL(mean, DATA_TYPE, M, m);
+
+
+    /* Initialize array(s). */
+    init_array (m, n, &float_n, POLYBENCH_ARRAY(data));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_covariance (m, n, float_n,
+                       POLYBENCH_ARRAY(data),
+                       POLYBENCH_ARRAY(cov),
+                       POLYBENCH_ARRAY(mean));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(m, POLYBENCH_ARRAY(cov)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(data);
+    POLYBENCH_FREE_ARRAY(cov);
+    POLYBENCH_FREE_ARRAY(mean);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/covariance/covariance.h
+++ b/benchmarks/Polybench/4.2/covariance/covariance.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _COVARIANCE_H
+# define _COVARIANCE_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 28
+#   define N 32
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 80
+#   define N 100
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 240
+#   define N 260
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1200
+#   define N 1400
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2600
+#   define N 3000
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_COVARIANCE_H */

--- a/benchmarks/Polybench/4.2/covariance/covariance.h
+++ b/benchmarks/Polybench/4.2/covariance/covariance.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/data.json
+++ b/benchmarks/Polybench/4.2/data.json
@@ -1,0 +1,4 @@
+{
+	"names": ["2mm", "3mm", "adi", "atax", "bicg", "cholesky", "correlation", "covariance", "deriche", "doitgen", "durbin", "gemm", "gemver", "gesummv", "gramschmidt", "heat-3d", "jacobi-1d", "jacobi-2d", "lu", "ludcmp", "mvt", "seidel-2d", "symm", "syr2k", "syrk", "trisolv", "trmm"],
+	"sizes": ["MINI", "SMALL", "MEDIUM", "LARGE", "EXTRALARGE"]
+}

--- a/benchmarks/Polybench/4.2/deriche/deriche.c
+++ b/benchmarks/Polybench/4.2/deriche/deriche.c
@@ -1,0 +1,214 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* deriche.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "deriche.h"
+
+
+/* Array initialization. */
+static
+void init_array (int w, int h, DATA_TYPE* alpha,
+                 DATA_TYPE POLYBENCH_2D(imgIn, W, H, w, h),
+                 DATA_TYPE POLYBENCH_2D(imgOut, W, H, w, h))
+{
+    int i, j;
+
+    *alpha = 0.25; //parameter of the filter
+
+    //input should be between 0 and 1 (grayscale image pixel)
+    for (i = 0; i < w; i++)
+        for (j = 0; j < h; j++)
+            imgIn[i][j] = (DATA_TYPE) ((313 * i + 991 * j) % 65536) / 65535.0f;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int w, int h,
+                 DATA_TYPE POLYBENCH_2D(imgOut, W, H, w, h))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("imgOut");
+    for (i = 0; i < w; i++)
+        for (j = 0; j < h; j++)
+        {
+            if ((i * h + j) % 20 == 0) fprintf(POLYBENCH_DUMP_TARGET, "\n");
+            fprintf(POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, imgOut[i][j]);
+        }
+    POLYBENCH_DUMP_END("imgOut");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+/* Original code provided by Gael Deest */
+static
+void kernel_deriche(int w, int h, DATA_TYPE alpha,
+                    DATA_TYPE POLYBENCH_2D(imgIn, W, H, w, h),
+                    DATA_TYPE POLYBENCH_2D(imgOut, W, H, w, h),
+                    DATA_TYPE POLYBENCH_2D(y1, W, H, w, h),
+                    DATA_TYPE POLYBENCH_2D(y2, W, H, w, h))
+{
+    int i, j;
+    DATA_TYPE xm1, tm1, ym1, ym2;
+    DATA_TYPE xp1, xp2;
+    DATA_TYPE tp1, tp2;
+    DATA_TYPE yp1, yp2;
+
+    DATA_TYPE k;
+    DATA_TYPE a1, a2, a3, a4, a5, a6, a7, a8;
+    DATA_TYPE b1, b2, c1, c2;
+
+
+    k = (SCALAR_VAL(1.0) - EXP_FUN(-alpha)) * (SCALAR_VAL(1.0) - EXP_FUN(-alpha)) / (SCALAR_VAL(1.0) + SCALAR_VAL(2.0) * alpha * EXP_FUN(-alpha) - EXP_FUN(SCALAR_VAL(2.0) * alpha));
+    a1 = a5 = k;
+    a2 = a6 = k * EXP_FUN(-alpha) * (alpha - SCALAR_VAL(1.0));
+    a3 = a7 = k * EXP_FUN(-alpha) * (alpha + SCALAR_VAL(1.0));
+    a4 = a8 = -k * EXP_FUN(SCALAR_VAL(-2.0) * alpha);
+    b1 =  POW_FUN(SCALAR_VAL(2.0), -alpha);
+    b2 = -EXP_FUN(SCALAR_VAL(-2.0) * alpha);
+    c1 = c2 = 1;
+
+    for (i = 0; i < _PB_W; i++)
+    {
+        ym1 = SCALAR_VAL(0.0);
+        ym2 = SCALAR_VAL(0.0);
+        xm1 = SCALAR_VAL(0.0);
+        for (j = 0; j < _PB_H; j++)
+        {
+            y1[i][j] = a1 * imgIn[i][j] + a2 * xm1 + b1 * ym1 + b2 * ym2;
+            xm1 = imgIn[i][j];
+            ym2 = ym1;
+            ym1 = y1[i][j];
+        }
+    }
+
+    for (i = 0; i < _PB_W; i++)
+    {
+        yp1 = SCALAR_VAL(0.0);
+        yp2 = SCALAR_VAL(0.0);
+        xp1 = SCALAR_VAL(0.0);
+        xp2 = SCALAR_VAL(0.0);
+        for (j = _PB_H - 1; j >= 0; j--)
+        {
+            y2[i][j] = a3 * xp1 + a4 * xp2 + b1 * yp1 + b2 * yp2;
+            xp2 = xp1;
+            xp1 = imgIn[i][j];
+            yp2 = yp1;
+            yp1 = y2[i][j];
+        }
+    }
+
+    for (i = 0; i < _PB_W; i++)
+    {
+        for (j = 0; j < _PB_H; j++)
+        {
+            imgOut[i][j] = c1 * (y1[i][j] + y2[i][j]);
+        }
+    }
+
+
+
+    for (j = 0; j < _PB_H; j++)
+    {
+        tm1 = SCALAR_VAL(0.0);
+        ym1 = SCALAR_VAL(0.0);
+        ym2 = SCALAR_VAL(0.0);
+        for (i = 0; i < _PB_W; i++)
+        {
+            y1[i][j] = a5 * imgOut[i][j] + a6 * tm1 + b1 * ym1 + b2 * ym2;
+            tm1 = imgOut[i][j];
+            ym2 = ym1;
+            ym1 = y1 [i][j];
+        }
+    }
+
+
+
+    for (j = 0; j < _PB_H; j++)
+    {
+        tp1 = SCALAR_VAL(0.0);
+        tp2 = SCALAR_VAL(0.0);
+        yp1 = SCALAR_VAL(0.0);
+        yp2 = SCALAR_VAL(0.0);
+        for (i = _PB_W - 1; i >= 0; i--)
+        {
+            y2[i][j] = a7 * tp1 + a8 * tp2 + b1 * yp1 + b2 * yp2;
+            tp2 = tp1;
+            tp1 = imgOut[i][j];
+            yp2 = yp1;
+            yp1 = y2[i][j];
+        }
+    }
+
+    for (i = 0; i < _PB_W; i++)
+    {
+        for (j = 0; j < _PB_H; j++)
+            imgOut[i][j] = c2 * (y1[i][j] + y2[i][j]);
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int w = W;
+    int h = H;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    POLYBENCH_2D_ARRAY_DECL(imgIn, DATA_TYPE, W, H, w, h);
+    POLYBENCH_2D_ARRAY_DECL(imgOut, DATA_TYPE, W, H, w, h);
+    POLYBENCH_2D_ARRAY_DECL(y1, DATA_TYPE, W, H, w, h);
+    POLYBENCH_2D_ARRAY_DECL(y2, DATA_TYPE, W, H, w, h);
+
+
+    /* Initialize array(s). */
+    init_array (w, h, &alpha, POLYBENCH_ARRAY(imgIn), POLYBENCH_ARRAY(imgOut));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_deriche (w, h, alpha, POLYBENCH_ARRAY(imgIn), POLYBENCH_ARRAY(imgOut), POLYBENCH_ARRAY(y1), POLYBENCH_ARRAY(y2));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(w, h, POLYBENCH_ARRAY(imgOut)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(imgIn);
+    POLYBENCH_FREE_ARRAY(imgOut);
+    POLYBENCH_FREE_ARRAY(y1);
+    POLYBENCH_FREE_ARRAY(y2);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/deriche/deriche.h
+++ b/benchmarks/Polybench/4.2/deriche/deriche.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _DERICHE_H
+# define _DERICHE_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(W) && !defined(H)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define W 64
+#   define H 64
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define W 192
+#   define H 128
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define W 720
+#   define H 480
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define W 4096
+#   define H 2160
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define W 7680
+#   define H 4320
+#  endif
+
+
+#endif /* !(W H) */
+
+# define _PB_W POLYBENCH_LOOP_BOUND(W,w)
+# define _PB_H POLYBENCH_LOOP_BOUND(H,h)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_FLOAT
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_DERICHE_H */

--- a/benchmarks/Polybench/4.2/deriche/deriche.h
+++ b/benchmarks/Polybench/4.2/deriche/deriche.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_FLOAT
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/doitgen/doitgen.c
+++ b/benchmarks/Polybench/4.2/doitgen/doitgen.c
@@ -1,0 +1,134 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* doitgen.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "doitgen.h"
+
+
+/* Array initialization. */
+static
+void init_array(int nr, int nq, int np,
+                DATA_TYPE POLYBENCH_3D(A, NR, NQ, NP, nr, nq, np),
+                DATA_TYPE POLYBENCH_2D(C4, NP, NP, np, np))
+{
+    int i, j, k;
+
+    for (i = 0; i < nr; i++)
+        for (j = 0; j < nq; j++)
+            for (k = 0; k < np; k++)
+                A[i][j][k] = (DATA_TYPE) ((i * j + k) % np) / np;
+    for (i = 0; i < np; i++)
+        for (j = 0; j < np; j++)
+            C4[i][j] = (DATA_TYPE) (i * j % np) / np;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int nr, int nq, int np,
+                 DATA_TYPE POLYBENCH_3D(A, NR, NQ, NP, nr, nq, np))
+{
+    int i, j, k;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("A");
+    for (i = 0; i < nr; i++)
+        for (j = 0; j < nq; j++)
+            for (k = 0; k < np; k++)
+            {
+                if ((i * nq * np + j * np + k) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+                fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i][j][k]);
+            }
+    POLYBENCH_DUMP_END("A");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+void kernel_doitgen(int nr, int nq, int np,
+                    DATA_TYPE POLYBENCH_3D(A, NR, NQ, NP, nr, nq, np),
+                    DATA_TYPE POLYBENCH_2D(C4, NP, NP, np, np),
+                    DATA_TYPE POLYBENCH_1D(sum, NP, np))
+{
+    int r, q, p, s;
+
+    printf("_PB_NR = %d \t _PB_NQ = %d \t _PB_NP = %d \n", _PB_NR, _PB_NQ, _PB_NP);
+
+    for (r = 0; r < _PB_NR; r++)
+    {
+        for (q = 0; q < _PB_NQ; q++)
+        {
+            for (p = 0; p < _PB_NP; p++)
+            {
+                sum[p] = SCALAR_VAL(0.0);
+                for (s = 0; s < _PB_NP; s++)
+                    sum[p] += A[r][q][s] * C4[s][p];
+            }
+            for (p = 0; p < _PB_NP; p++)
+                A[r][q][p] = sum[p];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int nr = NR;
+    int nq = NQ;
+    int np = NP;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_3D_ARRAY_DECL(A, DATA_TYPE, NR, NQ, NP, nr, nq, np);
+    POLYBENCH_1D_ARRAY_DECL(sum, DATA_TYPE, NP, np);
+    POLYBENCH_2D_ARRAY_DECL(C4, DATA_TYPE, NP, NP, np, np);
+
+    /* Initialize array(s). */
+    init_array (nr, nq, np,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(C4));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_doitgen (nr, nq, np,
+                    POLYBENCH_ARRAY(A),
+                    POLYBENCH_ARRAY(C4),
+                    POLYBENCH_ARRAY(sum));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(nr, nq, np,  POLYBENCH_ARRAY(A)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(sum);
+    POLYBENCH_FREE_ARRAY(C4);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/doitgen/doitgen.h
+++ b/benchmarks/Polybench/4.2/doitgen/doitgen.h
@@ -1,0 +1,86 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _DOITGEN_H
+# define _DOITGEN_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(NQ) && !defined(NR) && !defined(NP)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define NQ 8
+#   define NR 10
+#   define NP 12
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define NQ 20
+#   define NR 25
+#   define NP 30
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define NQ 40
+#   define NR 50
+#   define NP 60
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define NQ 140
+#   define NR 150
+#   define NP 160
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define NQ 220
+#   define NR 250
+#   define NP 270
+#  endif
+
+
+#endif /* !(NQ NR NP) */
+
+# define _PB_NQ POLYBENCH_LOOP_BOUND(NQ,nq)
+# define _PB_NR POLYBENCH_LOOP_BOUND(NR,nr)
+# define _PB_NP POLYBENCH_LOOP_BOUND(NP,np)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_DOITGEN_H */

--- a/benchmarks/Polybench/4.2/doitgen/doitgen.h
+++ b/benchmarks/Polybench/4.2/doitgen/doitgen.h
@@ -56,13 +56,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/durbin/durbin.c
+++ b/benchmarks/Polybench/4.2/durbin/durbin.c
@@ -1,0 +1,139 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* durbin.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "durbin.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_1D(r, N, n))
+{
+    int i, j;
+
+    for (i = 0; i < n; i++)
+    {
+        r[i] = (n + 1 - i);
+    }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(y, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("y");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, y[i]);
+    }
+    POLYBENCH_DUMP_END("y");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_durbin(int n,
+                   DATA_TYPE POLYBENCH_1D(r, N, n),
+                   DATA_TYPE POLYBENCH_1D(y, N, n))
+{
+    DATA_TYPE z[N];
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    DATA_TYPE sum;
+
+    int i, k;
+
+
+    y[0] = -r[0];
+    beta = SCALAR_VAL(1.0);
+    alpha = -r[0];
+
+    for (k = 1; k < _PB_N; k++)
+    {
+        beta = (1 - alpha * alpha) * beta;
+        sum = SCALAR_VAL(0.0);
+
+        for (i = 0; i < k; i++)
+        {
+            sum += r[k - i - 1] * y[i];
+        }
+        alpha = - (r[k] + sum) / beta;
+
+        for (i = 0; i < k; i++)
+        {
+            z[i] = y[i] + alpha * y[k - i - 1];
+        }
+
+        for (i = 0; i < k; i++)
+        {
+            y[i] = z[i];
+        }
+        y[k] = alpha;
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_1D_ARRAY_DECL(r, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y, DATA_TYPE, N, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(r));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_durbin (n,
+                   POLYBENCH_ARRAY(r),
+                   POLYBENCH_ARRAY(y));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(y)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(r);
+    POLYBENCH_FREE_ARRAY(y);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/durbin/durbin.h
+++ b/benchmarks/Polybench/4.2/durbin/durbin.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _DURBIN_H
+# define _DURBIN_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_DURBIN_H */

--- a/benchmarks/Polybench/4.2/durbin/durbin.h
+++ b/benchmarks/Polybench/4.2/durbin/durbin.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/gemm/gemm.c
+++ b/benchmarks/Polybench/4.2/gemm/gemm.c
@@ -1,0 +1,144 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* gemm.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "gemm.h"
+
+
+/* Array initialization. */
+static
+void init_array(int ni, int nj, int nk,
+                DATA_TYPE *alpha,
+                DATA_TYPE *beta,
+                DATA_TYPE POLYBENCH_2D(C, NI, NJ, ni, nj),
+                DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk),
+                DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nj; j++)
+            C[i][j] = (DATA_TYPE) ((i * j + 1) % ni) / ni;
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nk; j++)
+            A[i][j] = (DATA_TYPE) (i * (j + 1) % nk) / nk;
+    for (i = 0; i < nk; i++)
+        for (j = 0; j < nj; j++)
+            B[i][j] = (DATA_TYPE) (i * (j + 2) % nj) / nj;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int ni, int nj,
+                 DATA_TYPE POLYBENCH_2D(C, NI, NJ, ni, nj))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("C");
+    for (i = 0; i < ni; i++)
+        for (j = 0; j < nj; j++)
+        {
+            if ((i * ni + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, C[i][j]);
+        }
+    POLYBENCH_DUMP_END("C");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_gemm(int ni, int nj, int nk,
+                 DATA_TYPE alpha,
+                 DATA_TYPE beta,
+                 DATA_TYPE POLYBENCH_2D(C, NI, NJ, ni, nj),
+                 DATA_TYPE POLYBENCH_2D(A, NI, NK, ni, nk),
+                 DATA_TYPE POLYBENCH_2D(B, NK, NJ, nk, nj))
+{
+    int i, j, k;
+
+
+
+    for (i = 0; i < _PB_NI; i++)
+    {
+        for (j = 0; j < _PB_NJ; j++)
+            C[i][j] *= beta;
+
+        for (k = 0; k < _PB_NK; k++)
+        {
+            for (j = 0; j < _PB_NJ; j++)
+                C[i][j] += alpha * A[i][k] * B[k][j];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int ni = NI;
+    int nj = NJ;
+    int nk = NK;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(C, DATA_TYPE, NI, NJ, ni, nj);
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, NI, NK, ni, nk);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, NK, NJ, nk, nj);
+
+    /* Initialize array(s). */
+    init_array (ni, nj, nk, &alpha, &beta,
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_gemm (ni, nj, nk,
+                 alpha, beta,
+                 POLYBENCH_ARRAY(C),
+                 POLYBENCH_ARRAY(A),
+                 POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(ni, nj,  POLYBENCH_ARRAY(C)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(C);
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/gemm/gemm.h
+++ b/benchmarks/Polybench/4.2/gemm/gemm.h
@@ -1,0 +1,86 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _GEMM_H
+# define _GEMM_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(NI) && !defined(NJ) && !defined(NK)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define NI 20
+#   define NJ 25
+#   define NK 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define NI 60
+#   define NJ 70
+#   define NK 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define NI 200
+#   define NJ 220
+#   define NK 240
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define NI 1000
+#   define NJ 1100
+#   define NK 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define NI 2000
+#   define NJ 2300
+#   define NK 2600
+#  endif
+
+
+#endif /* !(NI NJ NK) */
+
+# define _PB_NI POLYBENCH_LOOP_BOUND(NI,ni)
+# define _PB_NJ POLYBENCH_LOOP_BOUND(NJ,nj)
+# define _PB_NK POLYBENCH_LOOP_BOUND(NK,nk)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_GEMM_H */

--- a/benchmarks/Polybench/4.2/gemm/gemm.h
+++ b/benchmarks/Polybench/4.2/gemm/gemm.h
@@ -56,13 +56,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/gemver/gemver.c
+++ b/benchmarks/Polybench/4.2/gemver/gemver.c
@@ -1,0 +1,196 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* gemver.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "gemver.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE *alpha,
+                 DATA_TYPE *beta,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                 DATA_TYPE POLYBENCH_1D(u1, N, n),
+                 DATA_TYPE POLYBENCH_1D(v1, N, n),
+                 DATA_TYPE POLYBENCH_1D(u2, N, n),
+                 DATA_TYPE POLYBENCH_1D(v2, N, n),
+                 DATA_TYPE POLYBENCH_1D(w, N, n),
+                 DATA_TYPE POLYBENCH_1D(x, N, n),
+                 DATA_TYPE POLYBENCH_1D(y, N, n),
+                 DATA_TYPE POLYBENCH_1D(z, N, n))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+
+    DATA_TYPE fn = (DATA_TYPE)n;
+
+    for (i = 0; i < n; i++)
+    {
+        u1[i] = i;
+        u2[i] = ((i + 1) / fn) / 2.0;
+        v1[i] = ((i + 1) / fn) / 4.0;
+        v2[i] = ((i + 1) / fn) / 6.0;
+        y[i] = ((i + 1) / fn) / 8.0;
+        z[i] = ((i + 1) / fn) / 9.0;
+        x[i] = 0.0;
+        w[i] = 0.0;
+        for (j = 0; j < n; j++)
+            A[i][j] = (DATA_TYPE) (i * j % n) / n;
+    }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(w, N, n))
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("w");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, w[i]);
+    }
+    POLYBENCH_DUMP_END("w");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_gemver(int n,
+                   DATA_TYPE alpha,
+                   DATA_TYPE beta,
+                   DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                   DATA_TYPE POLYBENCH_1D(u1, N, n),
+                   DATA_TYPE POLYBENCH_1D(v1, N, n),
+                   DATA_TYPE POLYBENCH_1D(u2, N, n),
+                   DATA_TYPE POLYBENCH_1D(v2, N, n),
+                   DATA_TYPE POLYBENCH_1D(w, N, n),
+                   DATA_TYPE POLYBENCH_1D(x, N, n),
+                   DATA_TYPE POLYBENCH_1D(y, N, n),
+                   DATA_TYPE POLYBENCH_1D(z, N, n))
+{
+    int i, j;
+
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_N; j++)
+            A[i][j] = A[i][j] + u1[i] * v1[j] + u2[i] * v2[j];
+    }
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_N; j++)
+            x[i] = x[i] + beta * A[j][i] * y[j];
+    }
+
+
+    for (i = 0; i < _PB_N; i++)
+        x[i] = x[i] + z[i];
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_N; j++)
+            w[i] = w[i] +  alpha * A[i][j] * x[j];
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+    POLYBENCH_1D_ARRAY_DECL(u1, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(v1, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(u2, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(v2, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(w, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(x, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(z, DATA_TYPE, N, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, &alpha, &beta,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(u1),
+                POLYBENCH_ARRAY(v1),
+                POLYBENCH_ARRAY(u2),
+                POLYBENCH_ARRAY(v2),
+                POLYBENCH_ARRAY(w),
+                POLYBENCH_ARRAY(x),
+                POLYBENCH_ARRAY(y),
+                POLYBENCH_ARRAY(z));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_gemver (n, alpha, beta,
+                   POLYBENCH_ARRAY(A),
+                   POLYBENCH_ARRAY(u1),
+                   POLYBENCH_ARRAY(v1),
+                   POLYBENCH_ARRAY(u2),
+                   POLYBENCH_ARRAY(v2),
+                   POLYBENCH_ARRAY(w),
+                   POLYBENCH_ARRAY(x),
+                   POLYBENCH_ARRAY(y),
+                   POLYBENCH_ARRAY(z));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(w)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(u1);
+    POLYBENCH_FREE_ARRAY(v1);
+    POLYBENCH_FREE_ARRAY(u2);
+    POLYBENCH_FREE_ARRAY(v2);
+    POLYBENCH_FREE_ARRAY(w);
+    POLYBENCH_FREE_ARRAY(x);
+    POLYBENCH_FREE_ARRAY(y);
+    POLYBENCH_FREE_ARRAY(z);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/gemver/gemver.h
+++ b/benchmarks/Polybench/4.2/gemver/gemver.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _GEMVER_H
+# define _GEMVER_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_GEMVER_H */

--- a/benchmarks/Polybench/4.2/gemver/gemver.h
+++ b/benchmarks/Polybench/4.2/gemver/gemver.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/gesummv/gesummv.c
+++ b/benchmarks/Polybench/4.2/gesummv/gesummv.c
@@ -1,0 +1,150 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* gesummv.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "gesummv.h"
+
+
+/* Array initialization. */
+static
+void init_array(int n,
+                DATA_TYPE *alpha,
+                DATA_TYPE *beta,
+                DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(B, N, N, n, n),
+                DATA_TYPE POLYBENCH_1D(x, N, n))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+    for (i = 0; i < n; i++)
+    {
+        x[i] = (DATA_TYPE)( i % n) / n;
+        for (j = 0; j < n; j++)
+        {
+            A[i][j] = (DATA_TYPE) ((i * j + 1) % n) / n;
+            B[i][j] = (DATA_TYPE) ((i * j + 2) % n) / n;
+        }
+    }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(y, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("y");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, y[i]);
+    }
+    POLYBENCH_DUMP_END("y");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_gesummv(int n,
+                    DATA_TYPE alpha,
+                    DATA_TYPE beta,
+                    DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                    DATA_TYPE POLYBENCH_2D(B, N, N, n, n),
+                    DATA_TYPE POLYBENCH_1D(tmp, N, n),
+                    DATA_TYPE POLYBENCH_1D(x, N, n),
+                    DATA_TYPE POLYBENCH_1D(y, N, n))
+{
+    int i, j;
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        tmp[i] = SCALAR_VAL(0.0);
+        y[i] = SCALAR_VAL(0.0);
+
+        for (j = 0; j < _PB_N; j++)
+        {
+            tmp[i] = A[i][j] * x[j] + tmp[i];
+            y[i] = B[i][j] * x[j] + y[i];
+        }
+        y[i] = alpha * tmp[i] + beta * y[i];
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, N, N, n, n);
+    POLYBENCH_1D_ARRAY_DECL(tmp, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(x, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y, DATA_TYPE, N, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, &alpha, &beta,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B),
+                POLYBENCH_ARRAY(x));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_gesummv (n, alpha, beta,
+                    POLYBENCH_ARRAY(A),
+                    POLYBENCH_ARRAY(B),
+                    POLYBENCH_ARRAY(tmp),
+                    POLYBENCH_ARRAY(x),
+                    POLYBENCH_ARRAY(y));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(y)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+    POLYBENCH_FREE_ARRAY(tmp);
+    POLYBENCH_FREE_ARRAY(x);
+    POLYBENCH_FREE_ARRAY(y);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/gesummv/gesummv.h
+++ b/benchmarks/Polybench/4.2/gesummv/gesummv.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _GESUMMV_H
+# define _GESUMMV_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 90
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 250
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 1300
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 2800
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_GESUMMV_H */

--- a/benchmarks/Polybench/4.2/gesummv/gesummv.h
+++ b/benchmarks/Polybench/4.2/gesummv/gesummv.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/gramschmidt/gramschmidt.c
+++ b/benchmarks/Polybench/4.2/gramschmidt/gramschmidt.c
@@ -1,0 +1,162 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* gramschmidt.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "gramschmidt.h"
+
+
+/* Array initialization. */
+static
+void init_array(int m, int n,
+                DATA_TYPE POLYBENCH_2D(A, M, N, m, n),
+                DATA_TYPE POLYBENCH_2D(R, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(Q, M, N, m, n))
+{
+    int i, j;
+
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            A[i][j] = (((DATA_TYPE) ((i * j) % m) / m ) * 100) + 10;
+            Q[i][j] = 0.0;
+        }
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+            R[i][j] = 0.0;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int m, int n,
+                 DATA_TYPE POLYBENCH_2D(A, M, N, m, n),
+                 DATA_TYPE POLYBENCH_2D(R, N, N, n, n),
+                 DATA_TYPE POLYBENCH_2D(Q, M, N, m, n))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("R");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, R[i][j]);
+        }
+    POLYBENCH_DUMP_END("R");
+
+    POLYBENCH_DUMP_BEGIN("Q");
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, Q[i][j]);
+        }
+    POLYBENCH_DUMP_END("Q");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+/* QR Decomposition with Modified Gram Schmidt:
+ http://www.inf.ethz.ch/personal/gander/ */
+static
+void kernel_gramschmidt(int m, int n,
+                        DATA_TYPE POLYBENCH_2D(A, M, N, m, n),
+                        DATA_TYPE POLYBENCH_2D(R, N, N, n, n),
+                        DATA_TYPE POLYBENCH_2D(Q, M, N, m, n))
+{
+    int i, j, k;
+
+    DATA_TYPE nrm;
+
+
+    for (k = 0; k < _PB_N; k++)
+    {
+        nrm = SCALAR_VAL(0.0);
+
+        for (i = 0; i < _PB_M; i++)
+            nrm += A[i][k] * A[i][k];
+
+
+        R[k][k] = SQRT_FUN(nrm);
+
+
+        for (i = 0; i < _PB_M; i++)
+            Q[i][k] = A[i][k] / R[k][k];
+
+
+        for (j = k + 1; j < _PB_N; j++)
+        {
+            R[k][j] = SCALAR_VAL(0.0);
+            for (i = 0; i < _PB_M; i++)
+                R[k][j] += Q[i][k] * A[i][j];
+
+            for (i = 0; i < _PB_M; i++)
+                A[i][j] = A[i][j] - Q[i][k] * R[k][j];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int m = M;
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, M, N, m, n);
+    POLYBENCH_2D_ARRAY_DECL(R, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(Q, DATA_TYPE, M, N, m, n);
+
+    /* Initialize array(s). */
+    init_array (m, n,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(R),
+                POLYBENCH_ARRAY(Q));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_gramschmidt (m, n,
+                        POLYBENCH_ARRAY(A),
+                        POLYBENCH_ARRAY(R),
+                        POLYBENCH_ARRAY(Q));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(m, n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(R), POLYBENCH_ARRAY(Q)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(R);
+    POLYBENCH_FREE_ARRAY(Q);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/gramschmidt/gramschmidt.h
+++ b/benchmarks/Polybench/4.2/gramschmidt/gramschmidt.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _GRAMSCHMIDT_H
+# define _GRAMSCHMIDT_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 60
+#   define N 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 200
+#   define N 240
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1000
+#   define N 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2000
+#   define N 2600
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_GRAMSCHMIDT_H */

--- a/benchmarks/Polybench/4.2/gramschmidt/gramschmidt.h
+++ b/benchmarks/Polybench/4.2/gramschmidt/gramschmidt.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/heat-3d/heat-3d.c
+++ b/benchmarks/Polybench/4.2/heat-3d/heat-3d.c
@@ -1,0 +1,142 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* heat-3d.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "heat-3d.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_3D(A, N, N, N, n, n, n),
+                 DATA_TYPE POLYBENCH_3D(B, N, N, N, n, n, n))
+{
+    int i, j, k;
+
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+            for (k = 0; k < n; k++)
+                A[i][j][k] = B[i][j][k] = (DATA_TYPE) (i + j + (n - k)) * 10 / (n);
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_3D(A, N, N, N, n, n, n))
+
+{
+    int i, j, k;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("A");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+            for (k = 0; k < n; k++)
+            {
+                if ((i * n * n + j * n + k) % 20 == 0) fprintf(POLYBENCH_DUMP_TARGET, "\n");
+                fprintf(POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i][j][k]);
+            }
+    POLYBENCH_DUMP_END("A");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_heat_3d(int tsteps,
+                    int n,
+                    DATA_TYPE POLYBENCH_3D(A, N, N, N, n, n, n),
+                    DATA_TYPE POLYBENCH_3D(B, N, N, N, n, n, n))
+{
+    int t, i, j, k;
+
+
+    for (t = 1; t <= TSTEPS; t++)
+    {
+        for (i = 1; i < _PB_N - 1; i++)
+        {
+            for (j = 1; j < _PB_N - 1; j++)
+            {
+                for (k = 1; k < _PB_N - 1; k++)
+                {
+                    B[i][j][k] =   SCALAR_VAL(0.125) * (A[i + 1][j][k] - SCALAR_VAL(2.0) * A[i][j][k] + A[i - 1][j][k])
+                                   + SCALAR_VAL(0.125) * (A[i][j + 1][k] - SCALAR_VAL(2.0) * A[i][j][k] + A[i][j - 1][k])
+                                   + SCALAR_VAL(0.125) * (A[i][j][k + 1] - SCALAR_VAL(2.0) * A[i][j][k] + A[i][j][k - 1])
+                                   + A[i][j][k];
+                }
+            }
+        }
+
+
+
+        for (i = 1; i < _PB_N - 1; i++)
+        {
+            for (j = 1; j < _PB_N - 1; j++)
+            {
+                for (k = 1; k < _PB_N - 1; k++)
+                {
+                    A[i][j][k] =   SCALAR_VAL(0.125) * (B[i + 1][j][k] - SCALAR_VAL(2.0) * B[i][j][k] + B[i - 1][j][k])
+                                   + SCALAR_VAL(0.125) * (B[i][j + 1][k] - SCALAR_VAL(2.0) * B[i][j][k] + B[i][j - 1][k])
+                                   + SCALAR_VAL(0.125) * (B[i][j][k + 1] - SCALAR_VAL(2.0) * B[i][j][k] + B[i][j][k - 1])
+                                   + B[i][j][k];
+                }
+            }
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int tsteps = TSTEPS;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_3D_ARRAY_DECL(A, DATA_TYPE, N, N, N, n, n, n);
+    POLYBENCH_3D_ARRAY_DECL(B, DATA_TYPE, N, N, N, n, n, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_heat_3d (tsteps, n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(A)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/heat-3d/heat-3d.h
+++ b/benchmarks/Polybench/4.2/heat-3d/heat-3d.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _HEAT_3D_H
+# define _HEAT_3D_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(TSTEPS) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define TSTEPS 20
+#   define N 10
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define TSTEPS 40
+#   define N 20
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define TSTEPS 100
+#   define N 40
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define TSTEPS 500
+#   define N 120
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define TSTEPS 1000
+#   define N 200
+#  endif
+
+
+#endif /* !(TSTEPS N) */
+
+# define _PB_TSTEPS POLYBENCH_LOOP_BOUND(TSTEPS,tsteps)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_HEAT_3D_H */

--- a/benchmarks/Polybench/4.2/heat-3d/heat-3d.h
+++ b/benchmarks/Polybench/4.2/heat-3d/heat-3d.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/jacobi-1d/jacobi-1d.c
+++ b/benchmarks/Polybench/4.2/jacobi-1d/jacobi-1d.c
@@ -1,0 +1,119 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* jacobi-1d.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "jacobi-1d.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_1D(A, N, n),
+                 DATA_TYPE POLYBENCH_1D(B, N, n))
+{
+    int i;
+
+    for (i = 0; i < n; i++)
+    {
+        A[i] = ((DATA_TYPE) i + 2) / n;
+        B[i] = ((DATA_TYPE) i + 3) / n;
+    }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(A, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("A");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf(POLYBENCH_DUMP_TARGET, "\n");
+        fprintf(POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i]);
+    }
+    POLYBENCH_DUMP_END("A");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_jacobi_1d(int tsteps,
+                      int n,
+                      DATA_TYPE POLYBENCH_1D(A, N, n),
+                      DATA_TYPE POLYBENCH_1D(B, N, n))
+{
+    int t, i;
+
+
+
+    for (t = 0; t < _PB_TSTEPS; t++)
+    {
+        for (i = 1; i < _PB_N - 1; i++)
+            B[i] = 0.33333 * (A[i - 1] + A[i] + A[i + 1]);
+
+        for (i = 1; i < _PB_N - 1; i++)
+            A[i] = 0.33333 * (B[i - 1] + B[i] + B[i + 1]);
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int tsteps = TSTEPS;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_1D_ARRAY_DECL(A, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(B, DATA_TYPE, N, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_jacobi_1d(tsteps, n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(A)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/jacobi-1d/jacobi-1d.h
+++ b/benchmarks/Polybench/4.2/jacobi-1d/jacobi-1d.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _JACOBI_1D_H
+# define _JACOBI_1D_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(TSTEPS) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define TSTEPS 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define TSTEPS 40
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define TSTEPS 100
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define TSTEPS 500
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define TSTEPS 1000
+#   define N 4000
+#  endif
+
+
+#endif /* !(TSTEPS N) */
+
+# define _PB_TSTEPS POLYBENCH_LOOP_BOUND(TSTEPS,tsteps)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_JACOBI_1D_H */

--- a/benchmarks/Polybench/4.2/jacobi-1d/jacobi-1d.h
+++ b/benchmarks/Polybench/4.2/jacobi-1d/jacobi-1d.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/jacobi-2d/jacobi-2d.c
+++ b/benchmarks/Polybench/4.2/jacobi-2d/jacobi-2d.c
@@ -1,0 +1,126 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* jacobi-2d.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "jacobi-2d.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                 DATA_TYPE POLYBENCH_2D(B, N, N, n, n))
+{
+    int i, j;
+
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            A[i][j] = ((DATA_TYPE) i * (j + 2) + 2) / n;
+            B[i][j] = ((DATA_TYPE) i * (j + 3) + 3) / n;
+        }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("A");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf(POLYBENCH_DUMP_TARGET, "\n");
+            fprintf(POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i][j]);
+        }
+    POLYBENCH_DUMP_END("A");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_jacobi_2d(int tsteps,
+                      int n,
+                      DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                      DATA_TYPE POLYBENCH_2D(B, N, N, n, n))
+{
+    int t, i, j;
+
+
+    for (t = 0; t < _PB_TSTEPS; t++)
+    {
+        for (i = 1; i < _PB_N - 1; i++)
+        {
+            for (j = 1; j < _PB_N - 1; j++)
+                B[i][j] = SCALAR_VAL(0.2) * (A[i][j] + A[i][j - 1] + A[i][1 + j] + A[1 + i][j] + A[i - 1][j]);
+        }
+
+        for (i = 1; i < _PB_N - 1; i++)
+        {
+            for (j = 1; j < _PB_N - 1; j++)
+                A[i][j] = SCALAR_VAL(0.2) * (B[i][j] + B[i][j - 1] + B[i][1 + j] + B[1 + i][j] + B[i - 1][j]);
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int tsteps = TSTEPS;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, N, N, n, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_jacobi_2d(tsteps, n, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(A)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/jacobi-2d/jacobi-2d.h
+++ b/benchmarks/Polybench/4.2/jacobi-2d/jacobi-2d.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _JACOBI_2D_H
+# define _JACOBI_2D_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(TSTEPS) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define TSTEPS 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define TSTEPS 40
+#   define N 90
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define TSTEPS 100
+#   define N 250
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define TSTEPS 500
+#   define N 1300
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define TSTEPS 1000
+#   define N 2800
+#  endif
+
+
+#endif /* !(TSTEPS N) */
+
+# define _PB_TSTEPS POLYBENCH_LOOP_BOUND(TSTEPS,tsteps)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_JACOBI_2D_H */

--- a/benchmarks/Polybench/4.2/jacobi-2d/jacobi-2d.h
+++ b/benchmarks/Polybench/4.2/jacobi-2d/jacobi-2d.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/lu/lu.c
+++ b/benchmarks/Polybench/4.2/lu/lu.c
@@ -1,0 +1,144 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* lu.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "lu.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+    int i, j;
+
+    for (i = 0; i < n; i++)
+    {
+        for (j = 0; j <= i; j++)
+            A[i][j] = (DATA_TYPE)(-j % n) / n + 1;
+        for (j = i + 1; j < n; j++)
+        {
+            A[i][j] = 0;
+        }
+        A[i][i] = 1;
+    }
+
+    /* Make the matrix positive semi-definite. */
+    /* not necessary for LU, but using same code as cholesky */
+    int r, s, t;
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, N, N, n, n);
+    for (r = 0; r < n; ++r)
+        for (s = 0; s < n; ++s)
+            (POLYBENCH_ARRAY(B))[r][s] = 0;
+    for (t = 0; t < n; ++t)
+        for (r = 0; r < n; ++r)
+            for (s = 0; s < n; ++s)
+                (POLYBENCH_ARRAY(B))[r][s] += A[r][t] * A[s][t];
+    for (r = 0; r < n; ++r)
+        for (s = 0; s < n; ++s)
+            A[r][s] = (POLYBENCH_ARRAY(B))[r][s];
+    POLYBENCH_FREE_ARRAY(B);
+
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("A");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i][j]);
+        }
+    POLYBENCH_DUMP_END("A");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_lu(int n,
+               DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+    int i, j, k;
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < i; j++)
+        {
+            for (k = 0; k < j; k++)
+            {
+                A[i][j] -= A[i][k] * A[k][j];
+            }
+            A[i][j] /= A[j][j];
+        }
+
+        for (j = i; j < _PB_N; j++)
+        {
+            for (k = 0; k < i; k++)
+            {
+                A[i][j] -= A[i][k] * A[k][j];
+            }
+        }
+    }
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(A));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_lu (n, POLYBENCH_ARRAY(A));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(A)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/lu/lu.h
+++ b/benchmarks/Polybench/4.2/lu/lu.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _LU_H
+# define _LU_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_LU_H */

--- a/benchmarks/Polybench/4.2/lu/lu.h
+++ b/benchmarks/Polybench/4.2/lu/lu.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/ludcmp/ludcmp.c
+++ b/benchmarks/Polybench/4.2/ludcmp/ludcmp.c
@@ -1,0 +1,200 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* ludcmp.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "ludcmp.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                 DATA_TYPE POLYBENCH_1D(b, N, n),
+                 DATA_TYPE POLYBENCH_1D(x, N, n),
+                 DATA_TYPE POLYBENCH_1D(y, N, n))
+{
+    int i, j;
+    DATA_TYPE fn = (DATA_TYPE)n;
+
+    for (i = 0; i < n; i++)
+    {
+        x[i] = 0;
+        y[i] = 0;
+        b[i] = (i + 1) / fn / 2.0 + 4;
+    }
+
+    for (i = 0; i < n; i++)
+    {
+        for (j = 0; j <= i; j++)
+            A[i][j] = (DATA_TYPE)(-j % n) / n + 1;
+        for (j = i + 1; j < n; j++)
+        {
+            A[i][j] = 0;
+        }
+        A[i][i] = 1;
+    }
+
+    /* Make the matrix positive semi-definite. */
+    /* not necessary for LU, but using same code as cholesky */
+    int r, s, t;
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, N, N, n, n);
+    for (r = 0; r < n; ++r)
+        for (s = 0; s < n; ++s)
+            (POLYBENCH_ARRAY(B))[r][s] = 0;
+    for (t = 0; t < n; ++t)
+        for (r = 0; r < n; ++r)
+            for (s = 0; s < n; ++s)
+                (POLYBENCH_ARRAY(B))[r][s] += A[r][t] * A[s][t];
+    for (r = 0; r < n; ++r)
+        for (s = 0; s < n; ++s)
+            A[r][s] = (POLYBENCH_ARRAY(B))[r][s];
+    POLYBENCH_FREE_ARRAY(B);
+
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(x, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("x");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, x[i]);
+    }
+    POLYBENCH_DUMP_END("x");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_ludcmp(int n,
+                   DATA_TYPE POLYBENCH_2D(A, N, N, n, n),
+                   DATA_TYPE POLYBENCH_1D(b, N, n),
+                   DATA_TYPE POLYBENCH_1D(x, N, n),
+                   DATA_TYPE POLYBENCH_1D(y, N, n))
+{
+    int i, j, k;
+
+    DATA_TYPE w;
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < i; j++)
+        {
+            w = A[i][j];
+
+            for (k = 0; k < j; k++)
+            {
+                w -= A[i][k] * A[k][j];
+            }
+            A[i][j] = w / A[j][j];
+        }
+
+        for (j = i; j < _PB_N; j++)
+        {
+            w = A[i][j];
+
+            for (k = 0; k < i; k++)
+            {
+                w -= A[i][k] * A[k][j];
+            }
+            A[i][j] = w;
+        }
+    }
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        w = b[i];
+
+        for (j = 0; j < i; j++)
+            w -= A[i][j] * y[j];
+        y[i] = w;
+    }
+
+
+
+    for (i = _PB_N - 1; i >= 0; i--)
+    {
+        w = y[i];
+
+        for (j = i + 1; j < _PB_N; j++)
+            w -= A[i][j] * x[j];
+        x[i] = w / A[i][i];
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+    POLYBENCH_1D_ARRAY_DECL(b, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(x, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y, DATA_TYPE, N, n);
+
+
+    /* Initialize array(s). */
+    init_array (n,
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(b),
+                POLYBENCH_ARRAY(x),
+                POLYBENCH_ARRAY(y));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_ludcmp (n,
+                   POLYBENCH_ARRAY(A),
+                   POLYBENCH_ARRAY(b),
+                   POLYBENCH_ARRAY(x),
+                   POLYBENCH_ARRAY(y));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(x)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(b);
+    POLYBENCH_FREE_ARRAY(x);
+    POLYBENCH_FREE_ARRAY(y);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/ludcmp/ludcmp.h
+++ b/benchmarks/Polybench/4.2/ludcmp/ludcmp.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _LUDCMP_H
+# define _LUDCMP_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_LUDCMP_H */

--- a/benchmarks/Polybench/4.2/ludcmp/ludcmp.h
+++ b/benchmarks/Polybench/4.2/ludcmp/ludcmp.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/mvt/mvt.c
+++ b/benchmarks/Polybench/4.2/mvt/mvt.c
@@ -1,0 +1,156 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* mvt.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "mvt.h"
+
+
+/* Array initialization. */
+static
+void init_array(int n,
+                DATA_TYPE POLYBENCH_1D(x1, N, n),
+                DATA_TYPE POLYBENCH_1D(x2, N, n),
+                DATA_TYPE POLYBENCH_1D(y_1, N, n),
+                DATA_TYPE POLYBENCH_1D(y_2, N, n),
+                DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+    int i, j;
+
+    for (i = 0; i < n; i++)
+    {
+        x1[i] = (DATA_TYPE) (i % n) / n;
+        x2[i] = (DATA_TYPE) ((i + 1) % n) / n;
+        y_1[i] = (DATA_TYPE) ((i + 3) % n) / n;
+        y_2[i] = (DATA_TYPE) ((i + 4) % n) / n;
+        for (j = 0; j < n; j++)
+            A[i][j] = (DATA_TYPE) (i * j % n) / n;
+    }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(x1, N, n),
+                 DATA_TYPE POLYBENCH_1D(x2, N, n))
+
+{
+    int i;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("x1");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, x1[i]);
+    }
+    POLYBENCH_DUMP_END("x1");
+
+    POLYBENCH_DUMP_BEGIN("x2");
+    for (i = 0; i < n; i++)
+    {
+        if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+        fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, x2[i]);
+    }
+    POLYBENCH_DUMP_END("x2");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_mvt(int n,
+                DATA_TYPE POLYBENCH_1D(x1, N, n),
+                DATA_TYPE POLYBENCH_1D(x2, N, n),
+                DATA_TYPE POLYBENCH_1D(y_1, N, n),
+                DATA_TYPE POLYBENCH_1D(y_2, N, n),
+                DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+    int i, j;
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_N; j++)
+            x1[i] = x1[i] + A[i][j] * y_1[j];
+    }
+
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j < _PB_N; j++)
+            x2[i] = x2[i] + A[j][i] * y_2[j];
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+    POLYBENCH_1D_ARRAY_DECL(x1, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(x2, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y_1, DATA_TYPE, N, n);
+    POLYBENCH_1D_ARRAY_DECL(y_2, DATA_TYPE, N, n);
+
+
+    /* Initialize array(s). */
+    init_array (n,
+                POLYBENCH_ARRAY(x1),
+                POLYBENCH_ARRAY(x2),
+                POLYBENCH_ARRAY(y_1),
+                POLYBENCH_ARRAY(y_2),
+                POLYBENCH_ARRAY(A));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_mvt (n,
+                POLYBENCH_ARRAY(x1),
+                POLYBENCH_ARRAY(x2),
+                POLYBENCH_ARRAY(y_1),
+                POLYBENCH_ARRAY(y_2),
+                POLYBENCH_ARRAY(A));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(x1), POLYBENCH_ARRAY(x2)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(x1);
+    POLYBENCH_FREE_ARRAY(x2);
+    POLYBENCH_FREE_ARRAY(y_1);
+    POLYBENCH_FREE_ARRAY(y_2);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/mvt/mvt.h
+++ b/benchmarks/Polybench/4.2/mvt/mvt.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _MVT_H
+# define _MVT_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_MVT_H */

--- a/benchmarks/Polybench/4.2/mvt/mvt.h
+++ b/benchmarks/Polybench/4.2/mvt/mvt.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/polybench/polybench.c
+++ b/benchmarks/Polybench/4.2/polybench/polybench.c
@@ -1,0 +1,577 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* polybench.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <assert.h>
+#include <time.h>
+#include <sys/time.h>
+#ifdef __linux__ 
+	#include <sys/resource.h>
+#elif _WIN32
+    // Do not include <sys/resource.h>
+#else
+	#include <sys/resource.h>
+#endif
+
+#include <sched.h>
+#include <math.h>
+#ifdef _OPENMP
+# include <omp.h>
+#endif
+
+#if defined(POLYBENCH_PAPI)
+# undef POLYBENCH_PAPI
+# include "polybench.h"
+# define POLYBENCH_PAPI
+#else
+# include "polybench.h"
+#endif
+
+/* By default, collect PAPI counters on thread 0. */
+#ifndef POLYBENCH_THREAD_MONITOR
+# define POLYBENCH_THREAD_MONITOR 0
+#endif
+
+/* Total LLC cache size. By default 32+MB.. */
+#ifndef POLYBENCH_CACHE_SIZE_KB
+# define POLYBENCH_CACHE_SIZE_KB 32770
+#endif
+
+
+int polybench_papi_counters_threadid = POLYBENCH_THREAD_MONITOR;
+double polybench_program_total_flops = 0;
+
+#ifdef POLYBENCH_PAPI
+# include <papi.h>
+# define POLYBENCH_MAX_NB_PAPI_COUNTERS 96
+char* _polybench_papi_eventlist[] =
+{
+#include "papi_counters.list"
+  NULL
+};
+int polybench_papi_eventset;
+int polybench_papi_eventlist[POLYBENCH_MAX_NB_PAPI_COUNTERS];
+long_long polybench_papi_values[POLYBENCH_MAX_NB_PAPI_COUNTERS];
+
+#endif
+
+/*
+ * Allocation table, to enable inter-array padding. All data allocated
+ * with polybench_alloc_data should be freed with polybench_free_data.
+ *
+ */
+#define NB_INITIAL_TABLE_ENTRIES 512
+struct polybench_data_ptrs
+{
+  void** user_view;
+  void** real_ptr;
+  int nb_entries;
+  int nb_avail_entries;
+};
+static struct polybench_data_ptrs* _polybench_alloc_table = NULL;
+static size_t polybench_inter_array_padding_sz = 0;
+
+/* Timer code (gettimeofday). */
+double polybench_t_start, polybench_t_end;
+/* Timer code (RDTSC). */
+unsigned long long int polybench_c_start, polybench_c_end;
+
+static
+double rtclock()
+{
+#if defined(POLYBENCH_TIME) || defined(POLYBENCH_GFLOPS)
+  struct timeval Tp;
+  int stat;
+  stat = gettimeofday (&Tp, NULL);
+  if (stat != 0)
+    printf ("Error return from gettimeofday: %d", stat);
+  return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+#else
+  return 0;
+#endif
+}
+
+
+#ifdef POLYBENCH_CYCLE_ACCURATE_TIMER
+static
+unsigned long long int rdtsc()
+{
+  unsigned long long int ret = 0;
+  unsigned int cycles_lo;
+  unsigned int cycles_hi;
+  __asm__ volatile ("RDTSC" : "=a" (cycles_lo), "=d" (cycles_hi));
+  ret = (unsigned long long int)cycles_hi << 32 | cycles_lo;
+
+  return ret;
+}
+#endif
+
+void polybench_flush_cache()
+{
+  int cs = POLYBENCH_CACHE_SIZE_KB * 1024 / sizeof(double);
+  double* flush = (double*) calloc (cs, sizeof(double));
+  int i;
+  double tmp = 0.0;
+#ifdef _OPENMP
+//#pragma omp parallel for reduction(+:tmp) private(i)
+#endif
+  for (i = 0; i < cs; i++)
+    tmp += flush[i];
+  assert (tmp <= 10.0);
+  free (flush);
+}
+
+
+#ifdef POLYBENCH_LINUX_FIFO_SCHEDULER
+void polybench_linux_fifo_scheduler()
+{
+  /* Use FIFO scheduler to limit OS interference. Program must be run
+     as root, and this works only for Linux kernels. */
+  struct sched_param schedParam;
+  schedParam.sched_priority = sched_get_priority_max (SCHED_FIFO);
+  sched_setscheduler (0, SCHED_FIFO, &schedParam);
+}
+
+
+void polybench_linux_standard_scheduler()
+{
+  /* Restore to standard scheduler policy. */
+  struct sched_param schedParam;
+  schedParam.sched_priority = sched_get_priority_max (SCHED_OTHER);
+  sched_setscheduler (0, SCHED_OTHER, &schedParam);
+}
+#endif
+
+#ifdef POLYBENCH_PAPI
+
+static
+void test_fail(char *file, int line, char *call, int retval)
+{
+  char buf[128];
+
+  memset(buf, '\0', sizeof(buf));
+  if (retval != 0)
+    fprintf (stdout, "%-40s FAILED\nLine # %d\n", file, line);
+  else
+  {
+    fprintf (stdout, "%-40s SKIPPED\n", file);
+    fprintf (stdout, "Line # %d\n", line);
+  }
+  if (retval == PAPI_ESYS)
+  {
+    sprintf (buf, "System error in %s", call);
+    perror (buf);
+  }
+  else if (retval > 0)
+    fprintf (stdout, "Error: %s\n", call);
+  else if (retval == 0)
+    fprintf (stdout, "Error: %s\n", call);
+  else
+  {
+    char errstring[PAPI_MAX_STR_LEN];
+    // PAPI 5.4.3 has changed the API for PAPI_perror.
+#if defined (PAPI_VERSION) && ((PAPI_VERSION_MAJOR(PAPI_VERSION) == 5 && PAPI_VERSION_MINOR(PAPI_VERSION) >= 4) || PAPI_VERSION_MAJOR(PAPI_VERSION) > 5)
+    fprintf (stdout, "Error in %s: %s\n", call, PAPI_strerror(retval));
+#else
+    PAPI_perror (retval, errstring, PAPI_MAX_STR_LEN);
+    fprintf (stdout, "Error in %s: %s\n", call, errstring);
+#endif
+  }
+  fprintf (stdout, "\n");
+  if (PAPI_is_initialized ())
+    PAPI_shutdown ();
+  exit (1);
+}
+
+
+void polybench_papi_init()
+{
+# ifdef _OPENMP
+//#pragma omp parallel
+  {
+    #pragma omp master
+    {
+      if (omp_get_max_threads () < polybench_papi_counters_threadid)
+        polybench_papi_counters_threadid = omp_get_max_threads () - 1;
+    }
+    #pragma omp barrier
+
+    if (omp_get_thread_num () == polybench_papi_counters_threadid)
+    {
+# endif
+      int retval;
+      polybench_papi_eventset = PAPI_NULL;
+      if ((retval = PAPI_library_init (PAPI_VER_CURRENT)) != PAPI_VER_CURRENT)
+        test_fail (__FILE__, __LINE__, "PAPI_library_init", retval);
+      if ((retval = PAPI_create_eventset (&polybench_papi_eventset))
+      != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_create_eventset", retval);
+      int k;
+      for (k = 0; _polybench_papi_eventlist[k]; ++k)
+      {
+        if ((retval =
+        PAPI_event_name_to_code (_polybench_papi_eventlist[k],
+        &(polybench_papi_eventlist[k])))
+        != PAPI_OK)
+          test_fail (__FILE__, __LINE__, "PAPI_event_name_to_code", retval);
+      }
+      polybench_papi_eventlist[k] = 0;
+
+
+# ifdef _OPENMP
+    }
+  }
+  #pragma omp barrier
+# endif
+}
+
+
+void polybench_papi_close()
+{
+# ifdef _OPENMP
+//#pragma omp parallel
+  {
+    if (omp_get_thread_num () == polybench_papi_counters_threadid)
+    {
+# endif
+      int retval;
+      if ((retval = PAPI_destroy_eventset (&polybench_papi_eventset))
+      != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_destroy_eventset", retval);
+      if (PAPI_is_initialized ())
+        PAPI_shutdown ();
+# ifdef _OPENMP
+    }
+  }
+  #pragma omp barrier
+# endif
+}
+
+int polybench_papi_start_counter(int evid)
+{
+# ifndef POLYBENCH_NO_FLUSH_CACHE
+  polybench_flush_cache();
+# endif
+
+# ifdef _OPENMP
+  # pragma omp parallel
+  {
+    if (omp_get_thread_num () == polybench_papi_counters_threadid)
+    {
+# endif
+
+      int retval = 1;
+      char descr[PAPI_MAX_STR_LEN];
+      PAPI_event_info_t evinfo;
+      PAPI_event_code_to_name (polybench_papi_eventlist[evid], descr);
+      if (PAPI_add_event (polybench_papi_eventset,
+                          polybench_papi_eventlist[evid]) != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_add_event", 1);
+      if (PAPI_get_event_info (polybench_papi_eventlist[evid], &evinfo)
+          != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_get_event_info", retval);
+      if ((retval = PAPI_start (polybench_papi_eventset)) != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_start", retval);
+# ifdef _OPENMP
+    }
+  }
+  #pragma omp barrier
+# endif
+  return 0;
+}
+
+
+void polybench_papi_stop_counter(int evid)
+{
+# ifdef _OPENMP
+  # pragma omp parallel
+  {
+    if (omp_get_thread_num () == polybench_papi_counters_threadid)
+    {
+# endif
+      int retval;
+      long_long values[1];
+      values[0] = 0;
+      if ((retval = PAPI_read (polybench_papi_eventset, &values[0]))
+      != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_read", retval);
+
+      if ((retval = PAPI_stop (polybench_papi_eventset, NULL)) != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_stop", retval);
+
+      polybench_papi_values[evid] = values[0];
+
+      if ((retval = PAPI_remove_event
+      (polybench_papi_eventset,
+      polybench_papi_eventlist[evid])) != PAPI_OK)
+        test_fail (__FILE__, __LINE__, "PAPI_remove_event", retval);
+# ifdef _OPENMP
+    }
+  }
+  #pragma omp barrier
+# endif
+}
+
+
+void polybench_papi_print()
+{
+  int verbose = 0;
+# ifdef _OPENMP
+  # pragma omp parallel
+  {
+    if (omp_get_thread_num() == polybench_papi_counters_threadid)
+    {
+#ifdef POLYBENCH_PAPI_VERBOSE
+      verbose = 1;
+#endif
+      if (verbose)
+        printf ("On thread %d:\n", polybench_papi_counters_threadid);
+#endif
+      int evid;
+      for (evid = 0; polybench_papi_eventlist[evid] != 0; ++evid)
+      {
+        if (verbose)
+          printf ("%s=", _polybench_papi_eventlist[evid]);
+        printf ("%llu ", polybench_papi_values[evid]);
+        if (verbose)
+          printf ("\n");
+      }
+      printf ("\n");
+# ifdef _OPENMP
+    }
+  }
+  #pragma omp barrier
+# endif
+}
+
+#endif
+/* ! POLYBENCH_PAPI */
+
+void polybench_prepare_instruments()
+{
+#ifndef POLYBENCH_NO_FLUSH_CACHE
+  polybench_flush_cache ();
+#endif
+#ifdef POLYBENCH_LINUX_FIFO_SCHEDULER
+  polybench_linux_fifo_scheduler ();
+#endif
+}
+
+
+void polybench_timer_start()
+{
+  polybench_prepare_instruments ();
+#ifndef POLYBENCH_CYCLE_ACCURATE_TIMER
+  polybench_t_start = rtclock ();
+#else
+  polybench_c_start = rdtsc ();
+#endif
+}
+
+
+void polybench_timer_stop()
+{
+#ifndef POLYBENCH_CYCLE_ACCURATE_TIMER
+  polybench_t_end = rtclock ();
+#else
+  polybench_c_end = rdtsc ();
+#endif
+#ifdef POLYBENCH_LINUX_FIFO_SCHEDULER
+  polybench_linux_standard_scheduler ();
+#endif
+}
+
+
+void polybench_timer_print()
+{
+#ifdef POLYBENCH_GFLOPS
+  if  (polybench_program_total_flops == 0)
+  {
+    printf ("[PolyBench][WARNING] Program flops not defined, use polybench_set_program_flops(value)\n");
+    printf ("%0.6lf\n", polybench_t_end - polybench_t_start);
+  }
+  else
+    printf ("%0.2lf\n",
+            (polybench_program_total_flops /
+             (double)(polybench_t_end - polybench_t_start)) / 1000000000);
+#else
+# ifndef POLYBENCH_CYCLE_ACCURATE_TIMER
+  printf ("%0.6f\n", polybench_t_end - polybench_t_start);
+# else
+  printf ("%Ld\n", polybench_c_end - polybench_c_start);
+# endif
+#endif
+}
+
+/*
+ * These functions are used only if the user defines a specific
+ * inter-array padding. It grows a global structure,
+ * _polybench_alloc_table, which keeps track of the data allocated via
+ * polybench_alloc_data (on which inter-array padding is applied), so
+ * that the original, non-shifted pointer can be recovered when
+ * calling polybench_free_data.
+ *
+ */
+#ifdef POLYBENCH_ENABLE_INTARRAY_PAD
+static
+void grow_alloc_table()
+{
+  if (_polybench_alloc_table == NULL ||
+      (_polybench_alloc_table->nb_entries % NB_INITIAL_TABLE_ENTRIES) != 0 ||
+      _polybench_alloc_table->nb_avail_entries != 0)
+  {
+    /* Should never happen if the API is properly used. */
+    fprintf (stderr, "[ERROR] Inter-array padding requires to use polybench_alloc_data and polybench_free_data\n");
+    exit (1);
+  }
+  size_t sz = _polybench_alloc_table->nb_entries;
+  sz += NB_INITIAL_TABLE_ENTRIES;
+  _polybench_alloc_table->user_view =
+    realloc (_polybench_alloc_table->user_view, sz * sizeof(void*));
+  assert(_polybench_alloc_table->user_view != NULL);
+  _polybench_alloc_table->real_ptr =
+    realloc (_polybench_alloc_table->real_ptr, sz * sizeof(void*));
+  assert(_polybench_alloc_table->real_ptr != NULL);
+  _polybench_alloc_table->nb_avail_entries = NB_INITIAL_TABLE_ENTRIES;
+}
+
+static
+void* register_padded_pointer(void* ptr, size_t orig_sz, size_t padded_sz)
+{
+  if (_polybench_alloc_table == NULL)
+  {
+    fprintf (stderr, "[ERROR] Inter-array padding requires to use polybench_alloc_data and polybench_free_data\n");
+    exit (1);
+  }
+  if (_polybench_alloc_table->nb_avail_entries == 0)
+    grow_alloc_table ();
+  int id = _polybench_alloc_table->nb_entries++;
+  _polybench_alloc_table->real_ptr[id] = ptr;
+  _polybench_alloc_table->user_view[id] = ptr + (padded_sz - orig_sz);
+
+  return _polybench_alloc_table->user_view[id];
+}
+
+
+static
+void
+free_data_from_alloc_table (void* ptr)
+{
+  if (_polybench_alloc_table != NULL && _polybench_alloc_table->nb_entries > 0)
+  {
+    int i;
+    for (i = 0; i < _polybench_alloc_table->nb_entries; ++i)
+      if (_polybench_alloc_table->user_view[i] == ptr ||
+          _polybench_alloc_table->real_ptr[i] == ptr)
+        break;
+    if (i != _polybench_alloc_table->nb_entries)
+    {
+      free (_polybench_alloc_table->real_ptr[i]);
+      for (; i < _polybench_alloc_table->nb_entries - 1; ++i)
+      {
+        _polybench_alloc_table->user_view[i] =
+          _polybench_alloc_table->user_view[i + 1];
+        _polybench_alloc_table->real_ptr[i] =
+          _polybench_alloc_table->real_ptr[i + 1];
+      }
+      _polybench_alloc_table->nb_entries--;
+      _polybench_alloc_table->nb_avail_entries++;
+      if (_polybench_alloc_table->nb_entries == 0)
+      {
+        free (_polybench_alloc_table->user_view);
+        free (_polybench_alloc_table->real_ptr);
+        free (_polybench_alloc_table);
+        _polybench_alloc_table = NULL;
+      }
+    }
+  }
+}
+
+static
+void check_alloc_table_state()
+{
+  if (_polybench_alloc_table == NULL)
+  {
+    _polybench_alloc_table = (struct polybench_data_ptrs*)
+                             malloc (sizeof(struct polybench_data_ptrs));
+    assert(_polybench_alloc_table != NULL);
+    _polybench_alloc_table->user_view =
+      (void**) malloc (sizeof(void*) * NB_INITIAL_TABLE_ENTRIES);
+    assert(_polybench_alloc_table->user_view != NULL);
+    _polybench_alloc_table->real_ptr =
+      (void**) malloc (sizeof(void*) * NB_INITIAL_TABLE_ENTRIES);
+    assert(_polybench_alloc_table->real_ptr != NULL);
+    _polybench_alloc_table->nb_entries = 0;
+    _polybench_alloc_table->nb_avail_entries = NB_INITIAL_TABLE_ENTRIES;
+  }
+}
+
+#endif // !POLYBENCH_ENABLE_INTARRAY_PAD
+
+
+static
+void*
+xmalloc(size_t alloc_sz)
+{
+  void* ret = NULL;
+  /* By default, post-pad the arrays. Safe behavior, but likely useless. */
+  polybench_inter_array_padding_sz += POLYBENCH_INTER_ARRAY_PADDING_FACTOR;
+  size_t padded_sz = alloc_sz + polybench_inter_array_padding_sz;
+  int err = posix_memalign (&ret, 4096, padded_sz);
+  if (! ret || err)
+  {
+    fprintf (stderr, "[PolyBench] posix_memalign: cannot allocate memory");
+    exit (1);
+  }
+  /* Safeguard: this is invoked only if polybench.c has been compiled
+     with inter-array padding support from polybench.h. If so, move
+     the starting address of the allocation and return it to the
+     user. The original pointer is registered in an allocation table
+     internal to polybench.c. Data must then be freed using
+     polybench_free_data, which will inspect the allocation table to
+     free the original pointer.*/
+#ifdef POLYBENCH_ENABLE_INTARRAY_PAD
+  /* This moves the 'ret' pointer by (padded_sz - alloc_sz) positions, and
+  registers it in the lookup table for future free using
+  polybench_free_data. */
+  ret = register_padded_pointer(ret, alloc_sz, padded_sz);
+#endif
+
+  return ret;
+}
+
+
+void polybench_free_data(void* ptr)
+{
+#ifdef POLYBENCH_ENABLE_INTARRAY_PAD
+  free_data_from_alloc_table (ptr);
+#else
+  free (ptr);
+#endif
+}
+
+
+void* polybench_alloc_data(unsigned long long int n, int elt_size)
+{
+#ifdef POLYBENCH_ENABLE_INTARRAY_PAD
+  check_alloc_table_state ();
+#endif
+
+  /// FIXME: detect overflow!
+  size_t val = n;
+  val *= elt_size;
+  void* ret = xmalloc (val);
+
+  return ret;
+}

--- a/benchmarks/Polybench/4.2/polybench/polybench.h
+++ b/benchmarks/Polybench/4.2/polybench/polybench.h
@@ -1,0 +1,241 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/*
+ * polybench.h: this file is part of PolyBench/C
+ *
+ * Polybench header for instrumentation.
+ *
+ * Programs must be compiled with `-I utilities utilities/polybench.c'
+ *
+ * Optionally, one can define:
+ *
+ * -DPOLYBENCH_TIME, to report the execution time,
+ *   OR (exclusive):
+ * -DPOLYBENCH_PAPI, to use PAPI H/W counters (defined in polybench.c)
+ *
+ *
+ * See README or utilities/polybench.c for additional options.
+ *
+ */
+#ifndef POLYBENCH_H
+# define POLYBENCH_H
+
+# include <stdlib.h>
+
+/* Array padding. By default, none is used. */
+# ifndef POLYBENCH_PADDING_FACTOR
+/* default: */
+#  define POLYBENCH_PADDING_FACTOR 0
+# endif
+
+/* Inter-array padding, for use with . By default, none is used. */
+# ifndef POLYBENCH_INTER_ARRAY_PADDING_FACTOR
+/* default: */
+#  define POLYBENCH_INTER_ARRAY_PADDING_FACTOR 0
+#  undef POLYBENCH_ENABLE_INTARRAY_PAD
+# else
+#  define POLYBENCH_ENABLE_INTARRAY_PAD
+# endif
+
+
+/* C99 arrays in function prototype. By default, do not use. */
+# ifdef POLYBENCH_USE_C99_PROTO
+#  define POLYBENCH_C99_SELECT(x,y) y
+# else
+/* default: */
+#  define POLYBENCH_C99_SELECT(x,y) x
+# endif
+
+
+/* Scalar loop bounds in SCoPs. By default, use parametric loop bounds. */
+# ifdef POLYBENCH_USE_SCALAR_LB
+#  define POLYBENCH_LOOP_BOUND(x,y) x
+# else
+/* default: */
+#  define POLYBENCH_LOOP_BOUND(x,y) y
+# endif
+
+/* Use the 'restrict' keyword to declare that the different arrays do not
+ * alias. By default, we do not use it as it is only supported in C99 and
+ * even here several compilers do not properly get it.
+ */
+# ifdef POLYBENCH_USE_RESTRICT
+#  define POLYBENCH_RESTRICT restrict
+# else
+/* default: */
+#  define POLYBENCH_RESTRICT
+# endif
+
+/* Macros to reference an array. Generic for heap and stack arrays
+   (C99).  Each array dimensionality has his own macro, to be used at
+   declaration or as a function argument.
+   Example:
+   int b[x] => POLYBENCH_1D_ARRAY(b, x)
+   int A[N][N] => POLYBENCH_2D_ARRAY(A, N, N)
+*/
+# ifndef POLYBENCH_STACK_ARRAYS
+#  define POLYBENCH_ARRAY(x) *x
+#  ifdef POLYBENCH_ENABLE_INTARRAY_PAD
+#   define POLYBENCH_FREE_ARRAY(x) polybench_free_data((void*)x);
+#  else
+#   define POLYBENCH_FREE_ARRAY(x) free((void*)x);
+#  endif
+#  define POLYBENCH_DECL_VAR(x) (*x)
+# else
+#  define POLYBENCH_ARRAY(x) x
+#  define POLYBENCH_FREE_ARRAY(x)
+#  define POLYBENCH_DECL_VAR(x) x
+# endif
+/* Macros for using arrays in the function prototypes. */
+# define POLYBENCH_1D(var, dim1,ddim1) var[POLYBENCH_RESTRICT POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_2D(var, dim1, dim2, ddim1, ddim2) var[POLYBENCH_RESTRICT POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_3D(var, dim1, dim2, dim3, ddim1, ddim2, ddim3) var[POLYBENCH_RESTRICT POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim3,ddim3) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_4D(var, dim1, dim2, dim3, dim4, ddim1, ddim2, ddim3, ddim4) var[POLYBENCH_RESTRICT POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim3,ddim3) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim4,ddim4) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_5D(var, dim1, dim2, dim3, dim4, dim5, ddim1, ddim2, ddim3, ddim4, ddim5) var[POLYBENCH_RESTRICT POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim3,ddim3) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim4,ddim4) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim5,ddim5) + POLYBENCH_PADDING_FACTOR]
+/* Macros for using arrays within the functions. */
+# define POLYBENCH_1D_F(var, dim1,ddim1) var[POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_2D_F(var, dim1, dim2, ddim1, ddim2) var[POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_3D_F(var, dim1, dim2, dim3, ddim1, ddim2, ddim3) var[POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim3,ddim3) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_4D_F(var, dim1, dim2, dim3, dim4, ddim1, ddim2, ddim3, ddim4) var[POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim3,ddim3) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim4,ddim4) + POLYBENCH_PADDING_FACTOR]
+# define POLYBENCH_5D_F(var, dim1, dim2, dim3, dim4, dim5, ddim1, ddim2, ddim3, ddim4, ddim5) var[POLYBENCH_C99_SELECT(dim1,ddim1) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim2,ddim2) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim3,ddim3) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim4,ddim4) + POLYBENCH_PADDING_FACTOR][POLYBENCH_C99_SELECT(dim5,ddim5) + POLYBENCH_PADDING_FACTOR]
+
+
+/* Macros to allocate heap arrays.
+   Example:
+   polybench_alloc_2d_array(N, M, double) => allocates N x M x sizeof(double)
+					  and returns a pointer to the 2d array
+ */
+# define POLYBENCH_ALLOC_1D_ARRAY(n1, type)	\
+  (type(*)[n1 + POLYBENCH_PADDING_FACTOR])polybench_alloc_data (n1 + POLYBENCH_PADDING_FACTOR, sizeof(type))
+# define POLYBENCH_ALLOC_2D_ARRAY(n1, n2, type)		\
+  (type(*)[n1 + POLYBENCH_PADDING_FACTOR][n2 + POLYBENCH_PADDING_FACTOR])polybench_alloc_data ((n1 + POLYBENCH_PADDING_FACTOR) * (n2 + POLYBENCH_PADDING_FACTOR), sizeof(type))
+# define POLYBENCH_ALLOC_3D_ARRAY(n1, n2, n3, type)		\
+  (type(*)[n1 + POLYBENCH_PADDING_FACTOR][n2 + POLYBENCH_PADDING_FACTOR][n3 + POLYBENCH_PADDING_FACTOR])polybench_alloc_data ((n1 + POLYBENCH_PADDING_FACTOR) * (n2 + POLYBENCH_PADDING_FACTOR) * (n3 + POLYBENCH_PADDING_FACTOR), sizeof(type))
+# define POLYBENCH_ALLOC_4D_ARRAY(n1, n2, n3, n4, type)			\
+  (type(*)[n1 + POLYBENCH_PADDING_FACTOR][n2 + POLYBENCH_PADDING_FACTOR][n3 + POLYBENCH_PADDING_FACTOR][n4 + POLYBENCH_PADDING_FACTOR])polybench_alloc_data ((n1 + POLYBENCH_PADDING_FACTOR) * (n2 + POLYBENCH_PADDING_FACTOR) * (n3 + POLYBENCH_PADDING_FACTOR) * (n4 + POLYBENCH_PADDING_FACTOR), sizeof(type))
+# define POLYBENCH_ALLOC_5D_ARRAY(n1, n2, n3, n4, n5, type)		\
+  (type(*)[n1 + POLYBENCH_PADDING_FACTOR][n2 + POLYBENCH_PADDING_FACTOR][n3 + POLYBENCH_PADDING_FACTOR][n4 + POLYBENCH_PADDING_FACTOR][n5 + POLYBENCH_PADDING_FACTOR])polybench_alloc_data ((n1 + POLYBENCH_PADDING_FACTOR) * (n2 + POLYBENCH_PADDING_FACTOR) * (n3 + POLYBENCH_PADDING_FACTOR) * (n4 + POLYBENCH_PADDING_FACTOR) * (n5 + POLYBENCH_PADDING_FACTOR), sizeof(type))
+
+/* Macros for array declaration. */
+# ifndef POLYBENCH_STACK_ARRAYS
+#  define POLYBENCH_1D_ARRAY_DECL(var, type, dim1, ddim1)		\
+  type POLYBENCH_1D_F(POLYBENCH_DECL_VAR(var), dim1, ddim1); \
+  var = POLYBENCH_ALLOC_1D_ARRAY(POLYBENCH_C99_SELECT(dim1, ddim1), type);
+#  define POLYBENCH_2D_ARRAY_DECL(var, type, dim1, dim2, ddim1, ddim2)	\
+  type POLYBENCH_2D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, ddim1, ddim2); \
+  var = POLYBENCH_ALLOC_2D_ARRAY(POLYBENCH_C99_SELECT(dim1, ddim1), POLYBENCH_C99_SELECT(dim2, ddim2), type);
+#  define POLYBENCH_3D_ARRAY_DECL(var, type, dim1, dim2, dim3, ddim1, ddim2, ddim3) \
+  type POLYBENCH_3D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, dim3, ddim1, ddim2, ddim3); \
+  var = POLYBENCH_ALLOC_3D_ARRAY(POLYBENCH_C99_SELECT(dim1, ddim1), POLYBENCH_C99_SELECT(dim2, ddim2), POLYBENCH_C99_SELECT(dim3, ddim3), type);
+#  define POLYBENCH_4D_ARRAY_DECL(var, type, dim1, dim2, dim3, dim4, ddim1, ddim2, ddim3, ddim4) \
+  type POLYBENCH_4D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, dim3, dim4, ddim1, ddim2, ddim3, ddim4); \
+  var = POLYBENCH_ALLOC_4D_ARRAY(POLYBENCH_C99_SELECT(dim1, ddim1), POLYBENCH_C99_SELECT(dim2, ddim2), POLYBENCH_C99_SELECT(dim3, ddim3), POLYBENCH_C99_SELECT(dim4, ddim4), type);
+#  define POLYBENCH_5D_ARRAY_DECL(var, type, dim1, dim2, dim3, dim4, dim5, ddim1, ddim2, ddim3, ddim4, ddim5) \
+  type POLYBENCH_5D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, dim3, dim4, dim5, ddim1, ddim2, ddim3, ddim4, ddim5); \
+  var = POLYBENCH_ALLOC_5D_ARRAY(POLYBENCH_C99_SELECT(dim1, ddim1), POLYBENCH_C99_SELECT(dim2, ddim2), POLYBENCH_C99_SELECT(dim3, ddim3), POLYBENCH_C99_SELECT(dim4, ddim4), POLYBENCH_C99_SELECT(dim5, ddim5), type);
+# else
+#  define POLYBENCH_1D_ARRAY_DECL(var, type, dim1, ddim1)		\
+  type POLYBENCH_1D_F(POLYBENCH_DECL_VAR(var), dim1, ddim1);
+#  define POLYBENCH_2D_ARRAY_DECL(var, type, dim1, dim2, ddim1, ddim2)	\
+  type POLYBENCH_2D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, ddim1, ddim2);
+#  define POLYBENCH_3D_ARRAY_DECL(var, type, dim1, dim2, dim3, ddim1, ddim2, ddim3) \
+  type POLYBENCH_3D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, dim3, ddim1, ddim2, ddim3);
+#  define POLYBENCH_4D_ARRAY_DECL(var, type, dim1, dim2, dim3, dim4, ddim1, ddim2, ddim3, ddim4) \
+  type POLYBENCH_4D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, dim3, dim4, ddim1, ddim2, ddim3, ddim4);
+#  define POLYBENCH_5D_ARRAY_DECL(var, type, dim1, dim2, dim3, dim4, dim5, ddim1, ddim2, ddim3, ddim4, ddim5) \
+  type POLYBENCH_5D_F(POLYBENCH_DECL_VAR(var), dim1, dim2, dim3, dim4, dim5, ddim1, ddim2, ddim3, ddim4, ddim5);
+# endif
+
+
+/* Dead-code elimination macros. Use argc/argv for the run-time check. */
+# ifndef POLYBENCH_DUMP_ARRAYS
+#  define POLYBENCH_DCE_ONLY_CODE    if (argc > 42 && ! strcmp(argv[0], ""))
+# else
+#  define POLYBENCH_DCE_ONLY_CODE
+# endif
+
+#define POLYBENCH_DUMP_TARGET stderr
+#define POLYBENCH_DUMP_START    fprintf(POLYBENCH_DUMP_TARGET, "==BEGIN DUMP_ARRAYS==\n")
+#define POLYBENCH_DUMP_FINISH   fprintf(POLYBENCH_DUMP_TARGET, "==END   DUMP_ARRAYS==\n")
+#define POLYBENCH_DUMP_BEGIN(s) fprintf(POLYBENCH_DUMP_TARGET, "begin dump: %s", s)
+#define POLYBENCH_DUMP_END(s)   fprintf(POLYBENCH_DUMP_TARGET, "\nend   dump: %s\n", s)
+
+# define polybench_prevent_dce(func)		\
+  POLYBENCH_DCE_ONLY_CODE			\
+  func
+
+
+/* Performance-related instrumentation. See polybench.c */
+# define polybench_start_instruments
+# define polybench_stop_instruments
+# define polybench_print_instruments
+
+
+/* PAPI support. */
+# ifdef POLYBENCH_PAPI
+extern const unsigned int polybench_papi_eventlist[];
+#  undef polybench_start_instruments
+#  undef polybench_stop_instruments
+#  undef polybench_print_instruments
+#  define polybench_set_papi_thread_report(x)	\
+   polybench_papi_counters_threadid = x;
+#  define polybench_start_instruments				\
+  polybench_prepare_instruments();				\
+  polybench_papi_init();					\
+  int evid;							\
+  for (evid = 0; polybench_papi_eventlist[evid] != 0; evid++)	\
+    {								\
+      if (polybench_papi_start_counter(evid))			\
+	continue;						\
+
+#  define polybench_stop_instruments		\
+      polybench_papi_stop_counter(evid);	\
+    }						\
+  polybench_papi_close();			\
+
+#  define polybench_print_instruments polybench_papi_print();
+# endif
+
+
+/* Timing support. */
+# if defined(POLYBENCH_TIME) || defined(POLYBENCH_GFLOPS)
+#  undef polybench_start_instruments
+#  undef polybench_stop_instruments
+#  undef polybench_print_instruments
+#  define polybench_start_instruments polybench_timer_start();
+#  define polybench_stop_instruments polybench_timer_stop();
+#  define polybench_print_instruments polybench_timer_print();
+extern double polybench_program_total_flops;
+extern void polybench_timer_start();
+extern void polybench_timer_stop();
+extern void polybench_timer_print();
+# endif
+
+/* PAPI support. */
+# ifdef POLYBENCH_PAPI
+extern int polybench_papi_start_counter(int evid);
+extern void polybench_papi_stop_counter(int evid);
+extern void polybench_papi_init();
+extern void polybench_papi_close();
+extern void polybench_papi_print();
+# endif
+
+/* Function prototypes. */
+extern void* polybench_alloc_data(unsigned long long int n, int elt_size);
+extern void polybench_free_data(void* ptr);
+
+/* PolyBench internal functions that should not be directly called by */
+/* the user, unless when designing customized execution profiling */
+/* approaches. */
+extern void polybench_flush_cache();
+extern void polybench_prepare_instruments();
+
+
+#endif /* !POLYBENCH_H */

--- a/benchmarks/Polybench/4.2/seidel-2d/seidel-2d.c
+++ b/benchmarks/Polybench/4.2/seidel-2d/seidel-2d.c
@@ -1,0 +1,111 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* seidel-2d.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "seidel-2d.h"
+
+
+/* Array initialization. */
+static
+void init_array (int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+    int i, j;
+
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+            A[i][j] = ((DATA_TYPE) i * (j + 2) + 2) / n;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("A");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf(POLYBENCH_DUMP_TARGET, "\n");
+            fprintf(POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, A[i][j]);
+        }
+    POLYBENCH_DUMP_END("A");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_seidel_2d(int tsteps,
+                      int n,
+                      DATA_TYPE POLYBENCH_2D(A, N, N, n, n))
+{
+    int t, i, j;
+
+
+    for (t = 0; t <= _PB_TSTEPS - 1; t++)
+        for (i = 1; i <= _PB_N - 2; i++)
+            for (j = 1; j <= _PB_N - 2; j++)
+                A[i][j] = (A[i - 1][j - 1] + A[i - 1][j] + A[i - 1][j + 1]
+                           + A[i][j - 1] + A[i][j] + A[i][j + 1]
+                           + A[i + 1][j - 1] + A[i + 1][j] + A[i + 1][j + 1]) / SCALAR_VAL(9.0);
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int tsteps = TSTEPS;
+
+    /* Variable declaration/allocation. */
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, N, n, n);
+
+
+    /* Initialize array(s). */
+    init_array (n, POLYBENCH_ARRAY(A));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_seidel_2d (tsteps, n, POLYBENCH_ARRAY(A));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(A)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/seidel-2d/seidel-2d.h
+++ b/benchmarks/Polybench/4.2/seidel-2d/seidel-2d.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _SEIDEL_2D_H
+# define _SEIDEL_2D_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(TSTEPS) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define TSTEPS 20
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define TSTEPS 40
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define TSTEPS 100
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define TSTEPS 500
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define TSTEPS 1000
+#   define N 4000
+#  endif
+
+
+#endif /* !(TSTEPS N) */
+
+# define _PB_TSTEPS POLYBENCH_LOOP_BOUND(TSTEPS,tsteps)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_SEIDEL_2D_H */

--- a/benchmarks/Polybench/4.2/seidel-2d/seidel-2d.h
+++ b/benchmarks/Polybench/4.2/seidel-2d/seidel-2d.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/symm/symm.c
+++ b/benchmarks/Polybench/4.2/symm/symm.c
@@ -1,0 +1,150 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* symm.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "symm.h"
+
+
+/* Array initialization. */
+static
+void init_array(int m, int n,
+                DATA_TYPE *alpha,
+                DATA_TYPE *beta,
+                DATA_TYPE POLYBENCH_2D(C, M, N, m, n),
+                DATA_TYPE POLYBENCH_2D(A, M, M, m, m),
+                DATA_TYPE POLYBENCH_2D(B, M, N, m, n))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            C[i][j] = (DATA_TYPE) ((i + j) % 100) / m ;
+            B[i][j] = (DATA_TYPE) ((n + i - j) % 100) / m ;
+        }
+    for (i = 0; i < m; i++)
+    {
+        for (j = 0; j <= i; j++)
+            A[i][j] = (DATA_TYPE) ((i + j) % 100) / m ;
+        for (j = i + 1; j < m; j++)
+            A[i][j] = -999; //regions of arrays that should not be used
+    }
+
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int m, int n,
+                 DATA_TYPE POLYBENCH_2D(C, M, N, m, n))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("C");
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * m + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, C[i][j]);
+        }
+    POLYBENCH_DUMP_END("C");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_symm(int m, int n,
+                 DATA_TYPE alpha,
+                 DATA_TYPE beta,
+                 DATA_TYPE POLYBENCH_2D(C, M, N, m, n),
+                 DATA_TYPE POLYBENCH_2D(A, M, M, m, m),
+                 DATA_TYPE POLYBENCH_2D(B, M, N, m, n))
+{
+    int i, j, k;
+    DATA_TYPE temp2;
+
+
+    for (i = 0; i < _PB_M; i++)
+    {
+        for (j = 0; j < _PB_N; j++ )
+        {
+            temp2 = 0;
+            for (k = 0; k < i; k++)
+            {
+                C[k][j] += alpha * B[i][j] * A[i][k];
+                temp2 += B[k][j] * A[i][k];
+            }
+            C[i][j] = beta * C[i][j] + alpha * B[i][j] * A[i][i] + alpha * temp2;
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int m = M;
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(C, DATA_TYPE, M, N, m, n);
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, M, M, m, m);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, M, N, m, n);
+
+    /* Initialize array(s). */
+    init_array (m, n, &alpha, &beta,
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_symm (m, n,
+                 alpha, beta,
+                 POLYBENCH_ARRAY(C),
+                 POLYBENCH_ARRAY(A),
+                 POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(m, n, POLYBENCH_ARRAY(C)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(C);
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/symm/symm.h
+++ b/benchmarks/Polybench/4.2/symm/symm.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _SYMM_H
+# define _SYMM_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 60
+#   define N 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 200
+#   define N 240
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1000
+#   define N 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2000
+#   define N 2600
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_SYMM_H */

--- a/benchmarks/Polybench/4.2/symm/symm.h
+++ b/benchmarks/Polybench/4.2/symm/symm.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/syr2k/syr2k.c
+++ b/benchmarks/Polybench/4.2/syr2k/syr2k.c
@@ -1,0 +1,146 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* syr2k.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "syr2k.h"
+
+
+/* Array initialization. */
+static
+void init_array(int n, int m,
+                DATA_TYPE *alpha,
+                DATA_TYPE *beta,
+                DATA_TYPE POLYBENCH_2D(C, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(A, N, M, n, m),
+                DATA_TYPE POLYBENCH_2D(B, N, M, n, m))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+    for (i = 0; i < n; i++)
+        for (j = 0; j < m; j++)
+        {
+            A[i][j] = (DATA_TYPE) ((i * j + 1) % n) / n;
+            B[i][j] = (DATA_TYPE) ((i * j + 2) % m) / m;
+        }
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            C[i][j] = (DATA_TYPE) ((i * j + 3) % n) / m;
+        }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(C, N, N, n, n))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("C");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, C[i][j]);
+        }
+    POLYBENCH_DUMP_END("C");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_syr2k(int n, int m,
+                  DATA_TYPE alpha,
+                  DATA_TYPE beta,
+                  DATA_TYPE POLYBENCH_2D(C, N, N, n, n),
+                  DATA_TYPE POLYBENCH_2D(A, N, M, n, m),
+                  DATA_TYPE POLYBENCH_2D(B, N, M, n, m))
+{
+    int i, j, k;
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j <= i; j++)
+            C[i][j] *= beta;
+
+        for (k = 0; k < _PB_M; k++)
+        {
+            for (j = 0; j <= i; j++)
+            {
+                C[i][j] += A[j][k] * alpha * B[i][k] + B[j][k] * alpha * A[i][k];
+            }
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int m = M;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(C, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, M, n, m);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, N, M, n, m);
+
+    /* Initialize array(s). */
+    init_array (n, m, &alpha, &beta,
+                POLYBENCH_ARRAY(C),
+                POLYBENCH_ARRAY(A),
+                POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_syr2k (n, m,
+                  alpha, beta,
+                  POLYBENCH_ARRAY(C),
+                  POLYBENCH_ARRAY(A),
+                  POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(C)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(C);
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/syr2k/syr2k.h
+++ b/benchmarks/Polybench/4.2/syr2k/syr2k.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _SYR2K_H
+# define _SYR2K_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 60
+#   define N 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 200
+#   define N 240
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1000
+#   define N 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2000
+#   define N 2600
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_SYR2K_H */

--- a/benchmarks/Polybench/4.2/syr2k/syr2k.h
+++ b/benchmarks/Polybench/4.2/syr2k/syr2k.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/syrk/syrk.c
+++ b/benchmarks/Polybench/4.2/syrk/syrk.c
@@ -1,0 +1,129 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* syrk.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "syrk.h"
+
+
+/* Array initialization. */
+static
+void init_array(int n, int m,
+                DATA_TYPE *alpha,
+                DATA_TYPE *beta,
+                DATA_TYPE POLYBENCH_2D(C, N, N, n, n),
+                DATA_TYPE POLYBENCH_2D(A, N, M, n, m))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    *beta = 1.2;
+    for (i = 0; i < n; i++)
+        for (j = 0; j < m; j++)
+            A[i][j] = (DATA_TYPE) ((i * j + 1) % n) / n;
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+            C[i][j] = (DATA_TYPE) ((i * j + 2) % m) / m;
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_2D(C, N, N, n, n))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("C");
+    for (i = 0; i < n; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * n + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, C[i][j]);
+        }
+    POLYBENCH_DUMP_END("C");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_syrk(int n, int m,
+                 DATA_TYPE alpha,
+                 DATA_TYPE beta,
+                 DATA_TYPE POLYBENCH_2D(C, N, N, n, n),
+                 DATA_TYPE POLYBENCH_2D(A, N, M, n, m))
+{
+    int i, j, k;
+
+
+
+    for (i = 0; i < _PB_N; i++)
+    {
+        for (j = 0; j <= i; j++)
+            C[i][j] *= beta;
+
+        for (k = 0; k < _PB_M; k++)
+        {
+            for (j = 0; j <= i; j++)
+                C[i][j] += alpha * A[i][k] * A[j][k];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int n = N;
+    int m = M;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    DATA_TYPE beta;
+    POLYBENCH_2D_ARRAY_DECL(C, DATA_TYPE, N, N, n, n);
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, N, M, n, m);
+
+    /* Initialize array(s). */
+    init_array (n, m, &alpha, &beta, POLYBENCH_ARRAY(C), POLYBENCH_ARRAY(A));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_syrk (n, m, alpha, beta, POLYBENCH_ARRAY(C), POLYBENCH_ARRAY(A));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(C)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(C);
+    POLYBENCH_FREE_ARRAY(A);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/syrk/syrk.h
+++ b/benchmarks/Polybench/4.2/syrk/syrk.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _SYRK_H
+# define _SYRK_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 60
+#   define N 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 200
+#   define N 240
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1000
+#   define N 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2000
+#   define N 2600
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_SYRK_H */

--- a/benchmarks/Polybench/4.2/syrk/syrk.h
+++ b/benchmarks/Polybench/4.2/syrk/syrk.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/trisolv/trisolv.c
+++ b/benchmarks/Polybench/4.2/trisolv/trisolv.c
@@ -1,0 +1,125 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* trisolv.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "trisolv.h"
+
+
+/* Array initialization. */
+static
+void init_array(int n,
+                DATA_TYPE POLYBENCH_2D(L, N, N, n, n),
+                DATA_TYPE POLYBENCH_1D(x, N, n),
+                DATA_TYPE POLYBENCH_1D(b, N, n))
+{
+  int i, j;
+
+  for (i = 0; i < n; i++)
+  {
+    x[i] = - 999;
+    b[i] =  i ;
+    for (j = 0; j <= i; j++)
+      L[i][j] = (DATA_TYPE) (i + n - j + 1) * 2 / n;
+  }
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int n,
+                 DATA_TYPE POLYBENCH_1D(x, N, n))
+
+{
+  int i;
+
+  POLYBENCH_DUMP_START;
+  POLYBENCH_DUMP_BEGIN("x");
+  for (i = 0; i < n; i++)
+  {
+    fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, x[i]);
+    if (i % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+  }
+  POLYBENCH_DUMP_END("x");
+  POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_trisolv(int n,
+                    DATA_TYPE POLYBENCH_2D(L, N, N, n, n),
+                    DATA_TYPE POLYBENCH_1D(x, N, n),
+                    DATA_TYPE POLYBENCH_1D(b, N, n))
+{
+  int i, j;
+
+
+  for (i = 0; i < _PB_N; i++)
+  {
+    x[i] = b[i];
+
+
+    for (j = 0; j < i; j++)
+      x[i] -= L[i][j] * x[j];
+
+
+    x[i] = x[i] / L[i][i];
+  }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+  /* Retrieve problem size. */
+  int n = N;
+
+  /* Variable declaration/allocation. */
+  POLYBENCH_2D_ARRAY_DECL(L, DATA_TYPE, N, N, n, n);
+  POLYBENCH_1D_ARRAY_DECL(x, DATA_TYPE, N, n);
+  POLYBENCH_1D_ARRAY_DECL(b, DATA_TYPE, N, n);
+
+
+  /* Initialize array(s). */
+  init_array (n, POLYBENCH_ARRAY(L), POLYBENCH_ARRAY(x), POLYBENCH_ARRAY(b));
+
+  /* Start timer. */
+  polybench_start_instruments;
+
+  /* Run kernel. */
+  kernel_trisolv (n, POLYBENCH_ARRAY(L), POLYBENCH_ARRAY(x), POLYBENCH_ARRAY(b));
+
+  /* Stop and print timer. */
+  polybench_stop_instruments;
+  polybench_print_instruments;
+
+  /* Prevent dead-code elimination. All live-out data must be printed
+     by the function call in argument. */
+  polybench_prevent_dce(print_array(n, POLYBENCH_ARRAY(x)));
+
+  /* Be clean. */
+  POLYBENCH_FREE_ARRAY(L);
+  POLYBENCH_FREE_ARRAY(x);
+  POLYBENCH_FREE_ARRAY(b);
+
+  return 0;
+}

--- a/benchmarks/Polybench/4.2/trisolv/trisolv.h
+++ b/benchmarks/Polybench/4.2/trisolv/trisolv.h
@@ -1,0 +1,74 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _TRISOLV_H
+# define _TRISOLV_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define N 40
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define N 120
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define N 400
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define N 2000
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define N 4000
+#  endif
+
+
+#endif /* !(N) */
+
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_TRISOLV_H */

--- a/benchmarks/Polybench/4.2/trisolv/trisolv.h
+++ b/benchmarks/Polybench/4.2/trisolv/trisolv.h
@@ -44,13 +44,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/benchmarks/Polybench/4.2/trmm/trmm.c
+++ b/benchmarks/Polybench/4.2/trmm/trmm.c
@@ -1,0 +1,131 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+/* trmm.c: this file is part of PolyBench/C */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <math.h>
+
+/* Include polybench common header. */
+#include "polybench.h"
+
+/* Include benchmark-specific header. */
+#include "trmm.h"
+
+
+/* Array initialization. */
+static
+void init_array(int m, int n,
+                DATA_TYPE *alpha,
+                DATA_TYPE POLYBENCH_2D(A, M, M, m, m),
+                DATA_TYPE POLYBENCH_2D(B, M, N, m, n))
+{
+    int i, j;
+
+    *alpha = 1.5;
+    for (i = 0; i < m; i++)
+    {
+        for (j = 0; j < i; j++)
+        {
+            A[i][j] = (DATA_TYPE)((i + j) % m) / m;
+        }
+        A[i][i] = 1.0;
+        for (j = 0; j < n; j++)
+        {
+            B[i][j] = (DATA_TYPE)((n + (i - j)) % n) / n;
+        }
+    }
+
+}
+
+
+/* DCE code. Must scan the entire live-out data.
+   Can be used also to check the correctness of the output. */
+static
+void print_array(int m, int n,
+                 DATA_TYPE POLYBENCH_2D(B, M, N, m, n))
+{
+    int i, j;
+
+    POLYBENCH_DUMP_START;
+    POLYBENCH_DUMP_BEGIN("B");
+    for (i = 0; i < m; i++)
+        for (j = 0; j < n; j++)
+        {
+            if ((i * m + j) % 20 == 0) fprintf (POLYBENCH_DUMP_TARGET, "\n");
+            fprintf (POLYBENCH_DUMP_TARGET, DATA_PRINTF_MODIFIER, B[i][j]);
+        }
+    POLYBENCH_DUMP_END("B");
+    POLYBENCH_DUMP_FINISH;
+}
+
+
+/* Main computational kernel. The whole function will be timed,
+   including the call and return. */
+static
+void kernel_trmm(int m, int n,
+                 DATA_TYPE alpha,
+                 DATA_TYPE POLYBENCH_2D(A, M, M, m, m),
+                 DATA_TYPE POLYBENCH_2D(B, M, N, m, n))
+{
+    int i, j, k;
+
+
+    for (i = 0; i < _PB_M; i++)
+    {
+        for (j = 0; j < _PB_N; j++)
+        {
+
+            for (k = i + 1; k < _PB_M; k++)
+                B[i][j] += A[k][i] * B[k][j];
+
+            B[i][j] = alpha * B[i][j];
+        }
+    }
+
+
+}
+
+
+int main(int argc, char** argv)
+{
+    /* Retrieve problem size. */
+    int m = M;
+    int n = N;
+
+    /* Variable declaration/allocation. */
+    DATA_TYPE alpha;
+    POLYBENCH_2D_ARRAY_DECL(A, DATA_TYPE, M, M, m, m);
+    POLYBENCH_2D_ARRAY_DECL(B, DATA_TYPE, M, N, m, n);
+
+    /* Initialize array(s). */
+    init_array (m, n, &alpha, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Start timer. */
+    polybench_start_instruments;
+
+    /* Run kernel. */
+    kernel_trmm (m, n, alpha, POLYBENCH_ARRAY(A), POLYBENCH_ARRAY(B));
+
+    /* Stop and print timer. */
+    polybench_stop_instruments;
+    polybench_print_instruments;
+
+    /* Prevent dead-code elimination. All live-out data must be printed
+       by the function call in argument. */
+    polybench_prevent_dce(print_array(m, n, POLYBENCH_ARRAY(B)));
+
+    /* Be clean. */
+    POLYBENCH_FREE_ARRAY(A);
+    POLYBENCH_FREE_ARRAY(B);
+
+    return 0;
+}

--- a/benchmarks/Polybench/4.2/trmm/trmm.h
+++ b/benchmarks/Polybench/4.2/trmm/trmm.h
@@ -1,0 +1,80 @@
+/**
+ * This version is stamped on May 10, 2016
+ *
+ * Contact:
+ *   Louis-Noel Pouchet <pouchet.ohio-state.edu>
+ *   Tomofumi Yuki <tomofumi.yuki.fr>
+ *
+ * Web address: http://polybench.sourceforge.net
+ */
+#ifndef _TRMM_H
+# define _TRMM_H
+
+/* Default to LARGE_DATASET. */
+# if !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(MEDIUM_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
+#  define LARGE_DATASET
+# endif
+
+# if !defined(M) && !defined(N)
+/* Define sample dataset sizes. */
+#  ifdef MINI_DATASET
+#   define M 20
+#   define N 30
+#  endif
+
+#  ifdef SMALL_DATASET
+#   define M 60
+#   define N 80
+#  endif
+
+#  ifdef MEDIUM_DATASET
+#   define M 200
+#   define N 240
+#  endif
+
+#  ifdef LARGE_DATASET
+#   define M 1000
+#   define N 1200
+#  endif
+
+#  ifdef EXTRALARGE_DATASET
+#   define M 2000
+#   define N 2600
+#  endif
+
+
+#endif /* !(M N) */
+
+# define _PB_M POLYBENCH_LOOP_BOUND(M,m)
+# define _PB_N POLYBENCH_LOOP_BOUND(N,n)
+
+
+/* Default data type */
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+#  define DATA_TYPE_IS_DOUBLE
+# endif
+
+#ifdef DATA_TYPE_IS_INT
+#  define DATA_TYPE int
+#  define DATA_PRINTF_MODIFIER "%d "
+#endif
+
+#ifdef DATA_TYPE_IS_FLOAT
+#  define DATA_TYPE float
+#  define DATA_PRINTF_MODIFIER "%0.2f "
+#  define SCALAR_VAL(x) x##f
+#  define SQRT_FUN(x) sqrtf(x)
+#  define EXP_FUN(x) expf(x)
+#  define POW_FUN(x,y) powf(x,y)
+# endif
+
+#ifdef DATA_TYPE_IS_DOUBLE
+#  define DATA_TYPE double
+#  define DATA_PRINTF_MODIFIER "%0.2lf "
+#  define SCALAR_VAL(x) x
+#  define SQRT_FUN(x) sqrt(x)
+#  define EXP_FUN(x) exp(x)
+#  define POW_FUN(x,y) pow(x,y)
+# endif
+
+#endif /* !_TRMM_H */

--- a/benchmarks/Polybench/4.2/trmm/trmm.h
+++ b/benchmarks/Polybench/4.2/trmm/trmm.h
@@ -50,13 +50,26 @@
 
 
 /* Default data type */
-# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE)
+# if !defined(DATA_TYPE_IS_INT) && !defined(DATA_TYPE_IS_FLOAT) && !defined(DATA_TYPE_IS_DOUBLE) && !defined(DATA_TYPE_IS_CHAR)
 #  define DATA_TYPE_IS_DOUBLE
 # endif
 
 #ifdef DATA_TYPE_IS_INT
 #  define DATA_TYPE int
 #  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (int) x
+#  define SQRT_FUN(x) ((int) sqrtf((float) x))
+#  define EXP_FUN(x) ((int) expf((float) x))
+#  define POW_FUN(x,y) ((int) powf((float) x, (float) y))
+#endif
+
+#ifdef DATA_TYPE_IS_CHAR
+#  define DATA_TYPE signed char
+#  define DATA_PRINTF_MODIFIER "%d "
+#  define SCALAR_VAL(x) (signed char) x
+#  define SQRT_FUN(x) ((char) sqrtf((float) x))
+#  define EXP_FUN(x) ((char) expf((float) x))
+#  define POW_FUN(x,y) ((char) powf((float) x, (float) y))
 #endif
 
 #ifdef DATA_TYPE_IS_FLOAT

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "edgecases"
   ],
   "dependencies": {
-    "@specs-feup/clava": "^3.0.8",
+    "@specs-feup/clava": "3.0.32",
     "@specs-feup/clava-code-transforms": "^1.0.1",
     "@specs-feup/lara": "^3.0.5",
     "chalk": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:app": "npx clava classic dist/test/TestLoadApp.js",
     "test:cortex-vision": "npx clava classic dist/test/TestLoadCortexSuiteVision.js -ncg",
     "test:rosetta": "npx clava classic  dist/test/TestLoadRosetta.js -ncg",
+    "test:polybench4_2": "npx clava classic  dist/test/TestLoadPolybench.js -ncg",
     "test:rosetta-single": "npx clava classic  dist/test/TestLoadRosettaSingle.js",
     "test:spec": "npx clava classic  dist/test/TestLoadSPEC.js"
   },

--- a/src/BenchmarkSuites.ts
+++ b/src/BenchmarkSuites.ts
@@ -266,3 +266,448 @@ export const SPEC2017: BenchmarkSuite = {
     },
     flags: ["-lm"]
 };
+
+export const POLYBENCH_4_2_MINI: BenchmarkSuite = {
+    name: "POLYBENCH4.2",
+    path: "benchmarks/Polybench/4.2/",
+    apps: {
+        "2mm": {
+            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
+        },
+        "3mm": {
+            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
+        },
+        "adi": {
+            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
+        },
+        "atax": {
+            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
+        },
+        "bicg": {
+            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
+        },
+        "cholesky": {
+            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
+        },
+        "correlation": {
+            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
+        },
+        "covariance": {
+            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
+        },
+        "deriche": {
+            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
+        },
+        "doitgen": {
+            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
+        },
+        "durbin": {
+            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
+        },
+        "gemm": {
+            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
+        },
+        "gemver": {
+            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
+        },
+        "gesummv": {
+            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
+        },
+        "gramschmidt": {
+            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
+        },
+        "heat_3d": {
+            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_1d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
+        },
+        "lu": {
+            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
+        },
+        "ludcmp": {
+            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
+        },
+        "mvt": {
+            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
+        },
+        "seidel_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
+        },
+        "symm": {
+            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
+        },
+        "syr2k": {
+            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
+        },
+        "syrk": {
+            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
+        },
+        "trisolv": {
+            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
+        },
+        "trmm": {
+            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
+        }
+    },
+    flags: ["-lm", "-DPOLYBENCH_TIME", "-DMINI_DATASET"]
+}
+
+export const POLYBENCH_4_2_SMALL: BenchmarkSuite = {
+    name: "POLYBENCH4.2",
+    path: "benchmarks/Polybench/4.2/",
+    apps: {
+        "2mm": {
+            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
+        },
+        "3mm": {
+            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
+        },
+        "adi": {
+            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
+        },
+        "atax": {
+            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
+        },
+        "bicg": {
+            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
+        },
+        "cholesky": {
+            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
+        },
+        "correlation": {
+            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
+        },
+        "covariance": {
+            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
+        },
+        "deriche": {
+            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
+        },
+        "doitgen": {
+            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
+        },
+        "durbin": {
+            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
+        },
+        "gemm": {
+            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
+        },
+        "gemver": {
+            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
+        },
+        "gesummv": {
+            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
+        },
+        "gramschmidt": {
+            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
+        },
+        "heat_3d": {
+            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_1d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
+        },
+        "lu": {
+            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
+        },
+        "ludcmp": {
+            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
+        },
+        "mvt": {
+            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
+        },
+        "seidel_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
+        },
+        "symm": {
+            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
+        },
+        "syr2k": {
+            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
+        },
+        "syrk": {
+            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
+        },
+        "trisolv": {
+            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
+        },
+        "trmm": {
+            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
+        }
+    },
+    flags: ["-lm", "-DPOLYBENCH_TIME", "-DSMALL_DATASET"]
+}
+
+export const POLYBENCH_4_2_MEDIUM: BenchmarkSuite = {
+    name: "POLYBENCH4.2",
+    path: "benchmarks/Polybench/4.2/",
+    apps: {
+        "2mm": {
+            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
+        },
+        "3mm": {
+            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
+        },
+        "adi": {
+            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
+        },
+        "atax": {
+            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
+        },
+        "bicg": {
+            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
+        },
+        "cholesky": {
+            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
+        },
+        "correlation": {
+            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
+        },
+        "covariance": {
+            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
+        },
+        "deriche": {
+            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
+        },
+        "doitgen": {
+            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
+        },
+        "durbin": {
+            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
+        },
+        "gemm": {
+            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
+        },
+        "gemver": {
+            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
+        },
+        "gesummv": {
+            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
+        },
+        "gramschmidt": {
+            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
+        },
+        "heat_3d": {
+            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_1d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
+        },
+        "lu": {
+            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
+        },
+        "ludcmp": {
+            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
+        },
+        "mvt": {
+            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
+        },
+        "seidel_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
+        },
+        "symm": {
+            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
+        },
+        "syr2k": {
+            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
+        },
+        "syrk": {
+            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
+        },
+        "trisolv": {
+            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
+        },
+        "trmm": {
+            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
+        }
+    },
+    flags: ["-lm", "-DPOLYBENCH_TIME", "-DMEDIUM_DATASET"]
+}
+
+export const POLYBENCH_4_2_LARGE: BenchmarkSuite = {
+    name: "POLYBENCH4.2",
+    path: "benchmarks/Polybench/4.2/",
+    apps: {
+        "2mm": {
+            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
+        },
+        "3mm": {
+            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
+        },
+        "adi": {
+            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
+        },
+        "atax": {
+            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
+        },
+        "bicg": {
+            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
+        },
+        "cholesky": {
+            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
+        },
+        "correlation": {
+            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
+        },
+        "covariance": {
+            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
+        },
+        "deriche": {
+            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
+        },
+        "doitgen": {
+            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
+        },
+        "durbin": {
+            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
+        },
+        "gemm": {
+            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
+        },
+        "gemver": {
+            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
+        },
+        "gesummv": {
+            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
+        },
+        "gramschmidt": {
+            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
+        },
+        "heat_3d": {
+            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_1d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
+        },
+        "lu": {
+            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
+        },
+        "ludcmp": {
+            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
+        },
+        "mvt": {
+            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
+        },
+        "seidel_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
+        },
+        "symm": {
+            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
+        },
+        "syr2k": {
+            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
+        },
+        "syrk": {
+            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
+        },
+        "trisolv": {
+            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
+        },
+        "trmm": {
+            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
+        }
+    },
+    flags: ["-lm", "-DPOLYBENCH_TIME", "-DLARGE_DATASET"]
+}
+
+export const POLYBENCH_4_2_EXTRALARGE: BenchmarkSuite = {
+    name: "POLYBENCH4.2",
+    path: "benchmarks/Polybench/4.2/",
+    apps: {
+        "2mm": {
+            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
+        },
+        "3mm": {
+            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
+        },
+        "adi": {
+            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
+        },
+        "atax": {
+            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
+        },
+        "bicg": {
+            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
+        },
+        "cholesky": {
+            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
+        },
+        "correlation": {
+            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
+        },
+        "covariance": {
+            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
+        },
+        "deriche": {
+            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
+        },
+        "doitgen": {
+            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
+        },
+        "durbin": {
+            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
+        },
+        "gemm": {
+            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
+        },
+        "gemver": {
+            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
+        },
+        "gesummv": {
+            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
+        },
+        "gramschmidt": {
+            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
+        },
+        "heat_3d": {
+            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_1d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
+        },
+        "jacobi_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
+        },
+        "lu": {
+            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
+        },
+        "ludcmp": {
+            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
+        },
+        "mvt": {
+            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
+        },
+        "seidel_2d": {
+            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
+        },
+        "symm": {
+            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
+        },
+        "syr2k": {
+            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
+        },
+        "syrk": {
+            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
+        },
+        "trisolv": {
+            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
+        },
+        "trmm": {
+            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
+        }
+    },
+    flags: ["-lm", "-DPOLYBENCH_TIME", "-DEXTRALARGE_DATASET"]
+}

--- a/src/BenchmarkSuites.ts
+++ b/src/BenchmarkSuites.ts
@@ -367,88 +367,88 @@ class PolyBench_4_2 extends BenchmarkSuite<POLYBENCH_SIZES> {
             "benchmarks/Polybench/4.2/",
             {
                 "2mm": {
-                    standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "3mm": {
-                    standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "adi": {
-                    standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "atax": {
-                    standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "bicg": {
-                    standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "cholesky": {
-                    standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "correlation": {
-                    standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "covariance": {
-                    standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "deriche": {
-                    standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "doitgen": {
-                    standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "durbin": {
-                    standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "gemm": {
-                    standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "gemver": {
-                    standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "gesummv": {
-                    standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "gramschmidt": {
-                    standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "heat-3d": {
-                    standard: "c11", topFunction: "main", canonicalName: "heat-3d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "heat-3d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "jacobi-1d": {
-                    standard: "c11", topFunction: "main", canonicalName: "jacobi-1d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "jacobi-1d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "jacobi-2d": {
-                    standard: "c11", topFunction: "main", canonicalName: "jacobi-2d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "jacobi-2d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "lu": {
-                    standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "ludcmp": {
-                    standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "mvt": {
-                    standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "seidel-2d": {
-                    standard: "c11", topFunction: "main", canonicalName: "seidel-2d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "seidel-2d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "symm": {
-                    standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "syr2k": {
-                    standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "syrk": {
-                    standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "trisolv": {
-                    standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 },
                 "trmm": {
-                    standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                    standard: "gnu11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
                 }
             },
-            ["-lm", "-DPOLYBENCH_TIME"]
+            ["-lm", "-DPOLYBENCH_TIME", "-DDATA_TYPE_IS_CHAR"]
         );
     }
 }

--- a/src/BenchmarkSuites.ts
+++ b/src/BenchmarkSuites.ts
@@ -1,713 +1,456 @@
 import { BenchmarkSuite } from "./LiteBenchmarkLoader.js";
 
-export const APPS: BenchmarkSuite = {
-    name: "Apps",
-    path: "apps/",
-    apps: {
-        "disparity": { standard: "c11", topFunction: "top_level", canonicalName: "disparity" },
-        "doom": { standard: "c11", topFunction: "main", canonicalName: "doom" },
-        "edgedetect": { standard: "c++11", topFunction: "edge_detect", canonicalName: "edgedetect" },
-        "llama2": { standard: "c11", topFunction: "generate", canonicalName: "llama2" },
-        "llama2-transformed": { standard: "c11", topFunction: "llama2_loop", canonicalName: "llama2-transformed" }
-    },
-    flags: ["-lm"],
-};
-
-export const AXBENCH: BenchmarkSuite = {
-    name: "AxBench",
-    path: "benchmarks/AxBench/",
-    apps: {
-        "blackscholes": { standard: "c++17", topFunction: "BlkSchlsEqEuroNoDiv", canonicalName: "blackscholes" },
-        "fft": { standard: "c++17", topFunction: "radix2DitCooleyTykeyFft", canonicalName: "fft" },
-        "inversek2j": { standard: "c++17", topFunction: "main", canonicalName: "inversek2j" },
-        "jmeint": { standard: "c++17", topFunction: "main", canonicalName: "jmeint" },
-        "jpeg": { standard: "c++17", topFunction: "main", canonicalName: "jpeg" },
-        "kmeans": { standard: "c++17", topFunction: "segmentImage", canonicalName: "kmeans" },
-        "sobel": { standard: "c++17", topFunction: "main", canonicalName: "sobel" }
-    },
-    flags: []
-};
-
-export const CHSTONE: BenchmarkSuite = {
-    name: "CHStone",
-    path: "benchmarks/CHStone/",
-    apps: {
-        "adpcm": { standard: "c11", topFunction: "adpcm_main", canonicalName: "adpcm" },
-        "aes": { standard: "c11", topFunction: "aes_main", canonicalName: "aes" },
-        "blowfish": { standard: "c11", topFunction: "blowfish_main", canonicalName: "blowfish" },
-        "dfadd": { standard: "c11", topFunction: "float64_add", canonicalName: "dfadd" },
-        "dfdiv": { standard: "c11", topFunction: "float64_div", canonicalName: "dfdiv" },
-        "dfmul": { standard: "c11", topFunction: "float64_mul", canonicalName: "dfmul" },
-        "dfsin": { standard: "c11", topFunction: "_sin", canonicalName: "dfsin" },
-        "gsm": { standard: "c11", topFunction: "Gsm_LPC_Analysis", canonicalName: "gsm" },
-        "jpeg": { standard: "c11", topFunction: "jpeg2bmp_main", canonicalName: "jpeg" },
-        "mips": { standard: "c11", topFunction: "mips", canonicalName: "mips" },
-        "motion": { standard: "c11", topFunction: "main", canonicalName: "motion" },
-        "sha": { standard: "c11", topFunction: "sha_stream", canonicalName: "sha" }
-    },
-    flags: []
-};
-
-export const CORTEXSUITE_CORTEX: BenchmarkSuite = {
-    name: "CortexSuite-Cortex",
-    path: "benchmarks/CortexSuite-Cortex/",
-    apps: {
-        "cortex-clustering-kmeans": { standard: "c11", topFunction: "main", canonicalName: "cortex-clustering-kmeans" },
-        "cortex-clustering-spectral": { standard: "c11", topFunction: "main", canonicalName: "cortex-clustering-spectral" },
-        "cortex-cnn": { standard: "c11", topFunction: "main", canonicalName: "cortex-cnn" },
-        "cortex-dnn": { standard: "c11", topFunction: "main", canonicalName: "cortex-dnn" },
-        "cortex-lda": { standard: "c11", topFunction: "main", canonicalName: "cortex-lda" },
-        "cortex-liblinear": { standard: "c11", topFunction: "main", canonicalName: "cortex-liblinear" },
-        "cortex-motion-estimation": { standard: "c11", topFunction: "main", canonicalName: "cortex-motion-estimation" },
-        "cortex-rbm": { standard: "c11", topFunction: "main", canonicalName: "cortex-rbm" },
-        "cortex-sphinx": { standard: "c11", topFunction: "main", canonicalName: "cortex-sphinx" },
-        "cortex-srr": { standard: "c11", topFunction: "main", canonicalName: "cortex-srr" },
-        "cortex-svd3": { standard: "c11", topFunction: "main", canonicalName: "cortex-svd3" },
-        "cortex-word2vec-compute-accuracy": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-compute-accuracy" },
-        "cortex-word2vec-distance": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-distance" },
-        "cortex-word2vec-word2phrase": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-word2phrase" },
-        "cortex-word2vec-word2vec": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-word2vec" },
-        "cortex-word2vec-word-analogy": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-word-analogy" }
-    },
-    flags: []
-};
-
-export const CORTEXSUITE_VISION: BenchmarkSuite = {
-    name: "CortexSuite-Vision",
-    path: "benchmarks/CortexSuite-Vision/",
-    apps: {
-        "vision-disparity": {
-            standard: "c11",
-            topFunction: "getDisparity",
-            canonicalName: "disparity",
-            amalgamate: true,
-            extraFlags: ["-Dfullhd"],
-            extraFiles: ["../Makefile", "data/fullhd"]
-        },
-        "vision-localization": {
-            standard: "c11",
-            topFunction: "updateState",
-            altTopFunction: "initQuartenion",
-            canonicalName: "localization",
-            amalgamate: true,
-            extraFlags: ["-Dvga"],
-            extraFiles: ["../Makefile", "data/vga"]
-        },
-        "vision-mser": {
-            standard: "c11",
-            topFunction: "mser",
-            canonicalName: "mser",
-            amalgamate: true,
-            extraFlags: ["-Dfullhd"],
-            extraFiles: ["../Makefile", "data/fullhd"]
-        },
-        "vision-multi-ncut": {
-            standard: "c11",
-            topFunction: "segment_image",
-            canonicalName: "multi-ncut",
-            amalgamate: true,
-            extraFlags: ["-Dqcif"],
-            extraFiles: ["../Makefile", "data/qcif"]
-        },
-        "vision-pca": {
-            standard: "c11",
-            topFunction: "pca",
-            canonicalName: "pca",
-            amalgamate: true,
-            extraFiles: ["../Makefile", "data"]
-        },
-        "vision-sift": {
-            standard: "c11",
-            topFunction: "normalizeAndSIFT",
-            canonicalName: "sift",
-            amalgamate: true,
-            extraFlags: ["-Dfullhd"],
-            extraFiles: ["../Makefile", "data/fullhd"]
-        },
-        "vision-stitch": {
-            standard: "c11",
-            topFunction: "stitch",
-            canonicalName: "stitch",
-            amalgamate: true,
-            extraFlags: ["-Dfullhd"],
-            extraFiles: ["../Makefile", "data/fullhd"]
-        },
-        "vision-svm": {
-            standard: "c11",
-            topFunction: "svm",
-            canonicalName: "svm",
-            amalgamate: true,
-            extraFlags: ["-Dcif"],
-            extraFiles: ["../Makefile", "data/cif"]
-        },
-        "vision-texture-synthesis": {
-            standard: "c11",
-            topFunction: "create_texture",
-            canonicalName: "texture-synthesis",
-            amalgamate: true,
-            extraFlags: ["-Dfullhd"],
-            extraFiles: ["../Makefile", "data/fullhd"]
-        },
-        "vision-tracking": {
-            standard: "c11",
-            topFunction: "trackFeaturesPyramidalLK",
-            altTopFunction: "imagePreprocessing",
-            canonicalName: "tracking",
-            amalgamate: true,
-            extraFlags: ["-Dfullhd"],
-            extraFiles: ["../Makefile", "data/fullhd"]
-        }
-    },
-    flags: ["-DGENERATE_OUTPUT", "-DCHECK", "-lm"]
-};
-
-export const MACHSUITE: BenchmarkSuite = {
-    name: "MachSuite",
-    path: "benchmarks/MachSuite/",
-    apps: {
-        "aes": { standard: "c11", topFunction: "aes256_encrypt_ecb", canonicalName: "aes" },
-        "backprop": { standard: "c11", topFunction: "backprop", canonicalName: "backprop" },
-        "bfs-bulk": { standard: "c11", topFunction: "bfs", canonicalName: "bfs-bulk" },
-        "bfs-queue": { standard: "c11", topFunction: "bfs", canonicalName: "bfs-queue" },
-        "fft-strided": { standard: "c11", topFunction: "fft", canonicalName: "fft-strided" },
-        "fft-transpose": { standard: "c11", topFunction: "fft1D_512", canonicalName: "fft-transpose" },
-        "gemm-blocked": { standard: "c11", topFunction: "bbgemm", canonicalName: "gemm-blocked" },
-        "gemm-ncubed": { standard: "c11", topFunction: "gemm", canonicalName: "gemm-ncubed" },
-        "kmp": { standard: "c11", topFunction: "kmp", canonicalName: "kmp" },
-        "md-grid": { standard: "c11", topFunction: "md", canonicalName: "md-grid" },
-        "md-knn": { standard: "c11", topFunction: "md_kernel", canonicalName: "md-knn" },
-        "nw": { standard: "c11", topFunction: "needwun", canonicalName: "nw" },
-        "sort-merge": { standard: "c11", topFunction: "ms_mergesort", canonicalName: "sort-merge" },
-        "sort-radix": { standard: "c11", topFunction: "ss_sort", canonicalName: "sort-radix" },
-        "spmv-crs": { standard: "c11", topFunction: "spmv", canonicalName: "spmv-crs" },
-        "spmv-ellpack": { standard: "c11", topFunction: "ellpack", canonicalName: "spmv-ellpack" },
-        "stencil-2d": { standard: "c11", topFunction: "stencil", canonicalName: "stencil-2d" },
-        "stencil-3d": { standard: "c11", topFunction: "stencil3d", canonicalName: "stencil-3d" },
-        "viterbi": { standard: "c11", topFunction: "viterbi", canonicalName: "viterbi" }
-    },
-    flags: []
-};
-
-export const RODINIA: BenchmarkSuite = {
-    name: "Rodinia",
-    path: "benchmarks/Rodinia/",
-    apps: {
-        "backprop": { standard: "c11", topFunction: "main", canonicalName: "backprop" },
-        "bfs": { standard: "c11", topFunction: "main", canonicalName: "bfs" },
-        "b+tree": { standard: "c11", topFunction: "main", canonicalName: "b+tree" },
-        "cfd-euler3d": { standard: "c11", topFunction: "main", canonicalName: "cfd-euler3d" },
-        "cfd-euler3d-double": { standard: "c11", topFunction: "main", canonicalName: "cfd-euler3d-double" },
-        "cfd-pre-euler3d": { standard: "c11", topFunction: "main", canonicalName: "cfd-pre-euler3d" },
-        "cfd-pre-euler3d-double": { standard: "c11", topFunction: "main", canonicalName: "cfd-pre-euler3d-double" },
-        "heartwall": { standard: "c11", topFunction: "main", canonicalName: "heartwall" },
-        "hotspot": { standard: "c11", topFunction: "main", canonicalName: "hotspot" },
-        "hotspot3D": { standard: "c11", topFunction: "main", canonicalName: "hotspot3D" },
-        "kmeans": { standard: "c11", topFunction: "main", canonicalName: "kmeans" },
-        "lavaMD": { standard: "c11", topFunction: "main", canonicalName: "lavaMD" },
-        "leukocyte": { standard: "c11", topFunction: "main", canonicalName: "leukocyte" },
-        "lud": { standard: "c11", topFunction: "main", canonicalName: "lud" },
-        "myocyte": { standard: "c11", topFunction: "main", canonicalName: "myocyte" },
-        "nn": { standard: "c11", topFunction: "main", canonicalName: "nn" },
-        "nw": { standard: "c11", topFunction: "main", canonicalName: "nw" },
-        "particlefilter": { standard: "c11", topFunction: "main", canonicalName: "particlefilter" },
-        "pathfinder": { standard: "c11", topFunction: "main", canonicalName: "pathfinder" },
-        "srad-v1": { standard: "c11", topFunction: "main", canonicalName: "srad-v1" },
-        "srad-v2": { standard: "c11", topFunction: "main", canonicalName: "srad-v2" },
-        "streamcluster": { standard: "c11", topFunction: "main", canonicalName: "streamcluster" }
-    },
-    flags: []
-};
-
-export const ROSETTA: BenchmarkSuite = {
-    name: "Rosetta",
-    path: "benchmarks/Rosetta/",
-    apps: {
-        "3d-rendering": {
-            standard: "c++11",
-            topFunction: "rendering_sw",
-            canonicalName: "3d-rendering",
-            amalgamate: true
-        },
-        "digit-recognition": {
-            standard: "c++11",
-            topFunction: "DigitRec_sw",
-            canonicalName: "digit-recognition",
-            amalgamate: true
-        },
-        "face-detection": {
-            standard: "c++11",
-            topFunction: "face_detect_sw",
-            canonicalName: "face-detection",
-            amalgamate: true
-        },
-        "optical-flow": {
-            standard: "c++11",
-            topFunction: "optical_flow_sw",
-            canonicalName: "optical-flow",
-            amalgamate: true
-        },
-        "spam-filter": {
-            standard: "c++11",
-            topFunction: "SgdLR_sw",
-            canonicalName: "spam-filter",
-            altTopFunction: "main",
-            amalgamate: true
-        }
-    },
-    flags: ["-D SW"]
-};
-
-export const SPEC2017: BenchmarkSuite = {
-    name: "SPEC2017",
-    path: "benchmarks/SPEC2017/",
-    apps: {
-        "519_lbm_r": { standard: "c11", topFunction: "main", canonicalName: "519.lbm_r" },
-        "531_deepsjeng_r": { standard: "c++11", topFunction: "main", canonicalName: "531.deepsjeng_r" }
-    },
-    flags: ["-lm"]
-};
-
-export const POLYBENCH_4_2_MINI: BenchmarkSuite = {
-    name: "POLYBENCH4.2",
-    path: "benchmarks/Polybench/4.2/",
-    apps: {
-        "2mm": {
-            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
-        },
-        "3mm": {
-            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
-        },
-        "adi": {
-            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
-        },
-        "atax": {
-            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
-        },
-        "bicg": {
-            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
-        },
-        "cholesky": {
-            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
-        },
-        "correlation": {
-            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
-        },
-        "covariance": {
-            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
-        },
-        "deriche": {
-            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
-        },
-        "doitgen": {
-            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
-        },
-        "durbin": {
-            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
-        },
-        "gemm": {
-            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
-        },
-        "gemver": {
-            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
-        },
-        "gesummv": {
-            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
-        },
-        "gramschmidt": {
-            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
-        },
-        "heat_3d": {
-            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_1d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
-        },
-        "lu": {
-            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
-        },
-        "ludcmp": {
-            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
-        },
-        "mvt": {
-            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
-        },
-        "seidel_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
-        },
-        "symm": {
-            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
-        },
-        "syr2k": {
-            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
-        },
-        "syrk": {
-            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
-        },
-        "trisolv": {
-            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
-        },
-        "trmm": {
-            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
-        }
-    },
-    flags: ["-lm", "-DPOLYBENCH_TIME", "-DMINI_DATASET"]
+export enum NOSIZES {
+    NA = ""
 }
 
-export const POLYBENCH_4_2_SMALL: BenchmarkSuite = {
-    name: "POLYBENCH4.2",
-    path: "benchmarks/Polybench/4.2/",
-    apps: {
-        "2mm": {
-            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
-        },
-        "3mm": {
-            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
-        },
-        "adi": {
-            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
-        },
-        "atax": {
-            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
-        },
-        "bicg": {
-            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
-        },
-        "cholesky": {
-            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
-        },
-        "correlation": {
-            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
-        },
-        "covariance": {
-            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
-        },
-        "deriche": {
-            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
-        },
-        "doitgen": {
-            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
-        },
-        "durbin": {
-            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
-        },
-        "gemm": {
-            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
-        },
-        "gemver": {
-            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
-        },
-        "gesummv": {
-            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
-        },
-        "gramschmidt": {
-            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
-        },
-        "heat_3d": {
-            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_1d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
-        },
-        "lu": {
-            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
-        },
-        "ludcmp": {
-            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
-        },
-        "mvt": {
-            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
-        },
-        "seidel_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
-        },
-        "symm": {
-            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
-        },
-        "syr2k": {
-            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
-        },
-        "syrk": {
-            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
-        },
-        "trisolv": {
-            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
-        },
-        "trmm": {
-            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
-        }
-    },
-    flags: ["-lm", "-DPOLYBENCH_TIME", "-DSMALL_DATASET"]
+class Apps extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "Apps",
+            NOSIZES,
+            "apps/",
+            {
+                "disparity": { standard: "c11", topFunction: "top_level", canonicalName: "disparity", invalidInputSizes: [] },
+                "doom": { standard: "c11", topFunction: "main", canonicalName: "doom", invalidInputSizes: [] },
+                "edgedetect": { standard: "c++11", topFunction: "edge_detect", canonicalName: "edgedetect", invalidInputSizes: [] },
+                "llama2": { standard: "c11", topFunction: "generate", canonicalName: "llama2", invalidInputSizes: [] },
+                "llama2-transformed": { standard: "c11", topFunction: "llama2_loop", canonicalName: "llama2-transformed", invalidInputSizes: [] }
+            },
+            ["-lm"]
+        )
+    }
+};
+
+export const APPS: Apps = new Apps();
+
+class AXBench extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "AxBench",
+            NOSIZES,
+            "benchmarks/AxBench/",
+            {
+                "blackscholes": { standard: "c++17", topFunction: "BlkSchlsEqEuroNoDiv", canonicalName: "blackscholes", invalidInputSizes: [] },
+                "fft": { standard: "c++17", topFunction: "radix2DitCooleyTykeyFft", canonicalName: "fft", invalidInputSizes: [] },
+                "inversek2j": { standard: "c++17", topFunction: "main", canonicalName: "inversek2j", invalidInputSizes: [] },
+                "jmeint": { standard: "c++17", topFunction: "main", canonicalName: "jmeint", invalidInputSizes: [] },
+                "jpeg": { standard: "c++17", topFunction: "main", canonicalName: "jpeg", invalidInputSizes: [] },
+                "kmeans": { standard: "c++17", topFunction: "segmentImage", canonicalName: "kmeans", invalidInputSizes: [] },
+                "sobel": { standard: "c++17", topFunction: "main", canonicalName: "sobel", invalidInputSizes: [] }
+            },
+            []
+        )
+    }
+};
+
+export const AXBENCH: AXBench = new AXBench();
+
+class CHStone extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "CHStone",
+            NOSIZES,
+            "benchmarks/CHStone/",
+            {
+                "adpcm": { standard: "c11", topFunction: "adpcm_main", canonicalName: "adpcm", invalidInputSizes: [] },
+                "aes": { standard: "c11", topFunction: "aes_main", canonicalName: "aes", invalidInputSizes: [] },
+                "blowfish": { standard: "c11", topFunction: "blowfish_main", canonicalName: "blowfish", invalidInputSizes: [] },
+                "dfadd": { standard: "c11", topFunction: "float64_add", canonicalName: "dfadd", invalidInputSizes: [] },
+                "dfdiv": { standard: "c11", topFunction: "float64_div", canonicalName: "dfdiv", invalidInputSizes: [] },
+                "dfmul": { standard: "c11", topFunction: "float64_mul", canonicalName: "dfmul", invalidInputSizes: [] },
+                "dfsin": { standard: "c11", topFunction: "_sin", canonicalName: "dfsin", invalidInputSizes: [] },
+                "gsm": { standard: "c11", topFunction: "Gsm_LPC_Analysis", canonicalName: "gsm", invalidInputSizes: [] },
+                "jpeg": { standard: "c11", topFunction: "jpeg2bmp_main", canonicalName: "jpeg", invalidInputSizes: [] },
+                "mips": { standard: "c11", topFunction: "mips", canonicalName: "mips", invalidInputSizes: [] },
+                "motion": { standard: "c11", topFunction: "main", canonicalName: "motion", invalidInputSizes: [] },
+                "sha": { standard: "c11", topFunction: "sha_stream", canonicalName: "sha", invalidInputSizes: [] }
+            },
+            []
+        );
+    }
+};
+
+export const CHSTONE: CHStone = new CHStone();
+
+class CortexSuite_Cortex extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "CortexSuite-Cortex",
+            NOSIZES,
+            "benchmarks/CortexSuite-Cortex/",
+            {
+                "cortex-clustering-kmeans": { standard: "c11", topFunction: "main", canonicalName: "cortex-clustering-kmeans", invalidInputSizes: [] },
+                "cortex-clustering-spectral": { standard: "c11", topFunction: "main", canonicalName: "cortex-clustering-spectral", invalidInputSizes: [] },
+                "cortex-cnn": { standard: "c11", topFunction: "main", canonicalName: "cortex-cnn", invalidInputSizes: [] },
+                "cortex-dnn": { standard: "c11", topFunction: "main", canonicalName: "cortex-dnn", invalidInputSizes: [] },
+                "cortex-lda": { standard: "c11", topFunction: "main", canonicalName: "cortex-lda", invalidInputSizes: [] },
+                "cortex-liblinear": { standard: "c11", topFunction: "main", canonicalName: "cortex-liblinear", invalidInputSizes: [] },
+                "cortex-motion-estimation": { standard: "c11", topFunction: "main", canonicalName: "cortex-motion-estimation", invalidInputSizes: [] },
+                "cortex-rbm": { standard: "c11", topFunction: "main", canonicalName: "cortex-rbm", invalidInputSizes: [] },
+                "cortex-sphinx": { standard: "c11", topFunction: "main", canonicalName: "cortex-sphinx", invalidInputSizes: [] },
+                "cortex-srr": { standard: "c11", topFunction: "main", canonicalName: "cortex-srr", invalidInputSizes: [] },
+                "cortex-svd3": { standard: "c11", topFunction: "main", canonicalName: "cortex-svd3", invalidInputSizes: [] },
+                "cortex-word2vec-compute-accuracy": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-compute-accuracy", invalidInputSizes: [] },
+                "cortex-word2vec-distance": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-distance", invalidInputSizes: [] },
+                "cortex-word2vec-word2phrase": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-word2phrase", invalidInputSizes: [] },
+                "cortex-word2vec-word2vec": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-word2vec", invalidInputSizes: [] },
+                "cortex-word2vec-word-analogy": { standard: "c11", topFunction: "main", canonicalName: "cortex-word2vec-word-analogy", invalidInputSizes: [] }
+            },
+            []
+        );
+    }
+
+};
+
+export const CORTEXSUITE_CORTEX: CortexSuite_Cortex = new CortexSuite_Cortex();
+
+class CortexSuite_Vision extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "CortexSuite-Vision",
+            NOSIZES,
+            "benchmarks/CortexSuite-Vision/",
+            {
+                "vision-disparity": {
+                    standard: "c11",
+                    topFunction: "getDisparity",
+                    canonicalName: "disparity",
+                    amalgamate: true,
+                    extraFlags: ["-Dfullhd"],
+                    extraFiles: ["../Makefile", "data/fullhd"],
+                    invalidInputSizes: []
+                },
+                "vision-localization": {
+                    standard: "c11",
+                    topFunction: "updateState",
+                    altTopFunction: "initQuartenion",
+                    canonicalName: "localization",
+                    amalgamate: true,
+                    extraFlags: ["-Dvga"],
+                    extraFiles: ["../Makefile", "data/vga"],
+                    invalidInputSizes: []
+                },
+                "vision-mser": {
+                    standard: "c11",
+                    topFunction: "mser",
+                    canonicalName: "mser",
+                    amalgamate: true,
+                    extraFlags: ["-Dfullhd"],
+                    extraFiles: ["../Makefile", "data/fullhd"],
+                    invalidInputSizes: []
+                },
+                "vision-multi-ncut": {
+                    standard: "c11",
+                    topFunction: "segment_image",
+                    canonicalName: "multi-ncut",
+                    amalgamate: true,
+                    extraFlags: ["-Dqcif"],
+                    extraFiles: ["../Makefile", "data/qcif"],
+                    invalidInputSizes: []
+                },
+                "vision-pca": {
+                    standard: "c11",
+                    topFunction: "pca",
+                    canonicalName: "pca",
+                    amalgamate: true,
+                    extraFiles: ["../Makefile", "data"],
+                    invalidInputSizes: []
+                },
+                "vision-sift": {
+                    standard: "c11",
+                    topFunction: "normalizeAndSIFT",
+                    canonicalName: "sift",
+                    amalgamate: true,
+                    extraFlags: ["-Dfullhd"],
+                    extraFiles: ["../Makefile", "data/fullhd"],
+                    invalidInputSizes: []
+                },
+                "vision-stitch": {
+                    standard: "c11",
+                    topFunction: "stitch",
+                    canonicalName: "stitch",
+                    amalgamate: true,
+                    extraFlags: ["-Dfullhd"],
+                    extraFiles: ["../Makefile", "data/fullhd"],
+                    invalidInputSizes: []
+                },
+                "vision-svm": {
+                    standard: "c11",
+                    topFunction: "svm",
+                    canonicalName: "svm",
+                    amalgamate: true,
+                    extraFlags: ["-Dcif"],
+                    extraFiles: ["../Makefile", "data/cif"],
+                    invalidInputSizes: []
+                },
+                "vision-texture-synthesis": {
+                    standard: "c11",
+                    topFunction: "create_texture",
+                    canonicalName: "texture-synthesis",
+                    amalgamate: true,
+                    extraFlags: ["-Dfullhd"],
+                    extraFiles: ["../Makefile", "data/fullhd"],
+                    invalidInputSizes: []
+                },
+                "vision-tracking": {
+                    standard: "c11",
+                    topFunction: "trackFeaturesPyramidalLK",
+                    altTopFunction: "imagePreprocessing",
+                    canonicalName: "tracking",
+                    amalgamate: true,
+                    extraFlags: ["-Dfullhd"],
+                    extraFiles: ["../Makefile", "data/fullhd"],
+                    invalidInputSizes: []
+                }
+            },
+            ["-DGENERATE_OUTPUT", "-DCHECK", "-lm"]
+        );
+    }
+
+};
+
+export const CORTEXSUITE_VISION: CortexSuite_Vision = new CortexSuite_Vision();
+
+class MachSuite extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "MachSuite",
+            NOSIZES,
+            "benchmarks/MachSuite/",
+            {
+                "aes": { standard: "c11", topFunction: "aes256_encrypt_ecb", canonicalName: "aes", invalidInputSizes: [] },
+                "backprop": { standard: "c11", topFunction: "backprop", canonicalName: "backprop", invalidInputSizes: [] },
+                "bfs-bulk": { standard: "c11", topFunction: "bfs", canonicalName: "bfs-bulk", invalidInputSizes: [] },
+                "bfs-queue": { standard: "c11", topFunction: "bfs", canonicalName: "bfs-queue", invalidInputSizes: [] },
+                "fft-strided": { standard: "c11", topFunction: "fft", canonicalName: "fft-strided", invalidInputSizes: [] },
+                "fft-transpose": { standard: "c11", topFunction: "fft1D_512", canonicalName: "fft-transpose", invalidInputSizes: [] },
+                "gemm-blocked": { standard: "c11", topFunction: "bbgemm", canonicalName: "gemm-blocked", invalidInputSizes: [] },
+                "gemm-ncubed": { standard: "c11", topFunction: "gemm", canonicalName: "gemm-ncubed", invalidInputSizes: [] },
+                "kmp": { standard: "c11", topFunction: "kmp", canonicalName: "kmp", invalidInputSizes: [] },
+                "md-grid": { standard: "c11", topFunction: "md", canonicalName: "md-grid", invalidInputSizes: [] },
+                "md-knn": { standard: "c11", topFunction: "md_kernel", canonicalName: "md-knn", invalidInputSizes: [] },
+                "nw": { standard: "c11", topFunction: "needwun", canonicalName: "nw", invalidInputSizes: [] },
+                "sort-merge": { standard: "c11", topFunction: "ms_mergesort", canonicalName: "sort-merge", invalidInputSizes: [] },
+                "sort-radix": { standard: "c11", topFunction: "ss_sort", canonicalName: "sort-radix", invalidInputSizes: [] },
+                "spmv-crs": { standard: "c11", topFunction: "spmv", canonicalName: "spmv-crs", invalidInputSizes: [] },
+                "spmv-ellpack": { standard: "c11", topFunction: "ellpack", canonicalName: "spmv-ellpack", invalidInputSizes: [] },
+                "stencil-2d": { standard: "c11", topFunction: "stencil", canonicalName: "stencil-2d", invalidInputSizes: [] },
+                "stencil-3d": { standard: "c11", topFunction: "stencil3d", canonicalName: "stencil-3d", invalidInputSizes: [] },
+                "viterbi": { standard: "c11", topFunction: "viterbi", canonicalName: "viterbi", invalidInputSizes: [] }
+            },
+            []
+        );
+    }
+};
+
+export const MACHSUITE: MachSuite = new MachSuite();
+
+class Rodinia extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "Rodinia",
+            NOSIZES,
+            "benchmarks/Rodinia/",
+            {
+                "backprop": { standard: "c11", topFunction: "main", canonicalName: "backprop", invalidInputSizes: [] },
+                "bfs": { standard: "c11", topFunction: "main", canonicalName: "bfs", invalidInputSizes: [] },
+                "b+tree": { standard: "c11", topFunction: "main", canonicalName: "b+tree", invalidInputSizes: [] },
+                "cfd-euler3d": { standard: "c11", topFunction: "main", canonicalName: "cfd-euler3d", invalidInputSizes: [] },
+                "cfd-euler3d-double": { standard: "c11", topFunction: "main", canonicalName: "cfd-euler3d-double", invalidInputSizes: [] },
+                "cfd-pre-euler3d": { standard: "c11", topFunction: "main", canonicalName: "cfd-pre-euler3d", invalidInputSizes: [] },
+                "cfd-pre-euler3d-double": { standard: "c11", topFunction: "main", canonicalName: "cfd-pre-euler3d-double", invalidInputSizes: [] },
+                "heartwall": { standard: "c11", topFunction: "main", canonicalName: "heartwall", invalidInputSizes: [] },
+                "hotspot": { standard: "c11", topFunction: "main", canonicalName: "hotspot", invalidInputSizes: [] },
+                "hotspot3D": { standard: "c11", topFunction: "main", canonicalName: "hotspot3D", invalidInputSizes: [] },
+                "kmeans": { standard: "c11", topFunction: "main", canonicalName: "kmeans", invalidInputSizes: [] },
+                "lavaMD": { standard: "c11", topFunction: "main", canonicalName: "lavaMD", invalidInputSizes: [] },
+                "leukocyte": { standard: "c11", topFunction: "main", canonicalName: "leukocyte", invalidInputSizes: [] },
+                "lud": { standard: "c11", topFunction: "main", canonicalName: "lud", invalidInputSizes: [] },
+                "myocyte": { standard: "c11", topFunction: "main", canonicalName: "myocyte", invalidInputSizes: [] },
+                "nn": { standard: "c11", topFunction: "main", canonicalName: "nn", invalidInputSizes: [] },
+                "nw": { standard: "c11", topFunction: "main", canonicalName: "nw", invalidInputSizes: [] },
+                "particlefilter": { standard: "c11", topFunction: "main", canonicalName: "particlefilter", invalidInputSizes: [] },
+                "pathfinder": { standard: "c11", topFunction: "main", canonicalName: "pathfinder", invalidInputSizes: [] },
+                "srad-v1": { standard: "c11", topFunction: "main", canonicalName: "srad-v1", invalidInputSizes: [] },
+                "srad-v2": { standard: "c11", topFunction: "main", canonicalName: "srad-v2", invalidInputSizes: [] },
+                "streamcluster": { standard: "c11", topFunction: "main", canonicalName: "streamcluster", invalidInputSizes: [] }
+            },
+            []
+        );
+    }
+};
+
+export const RODINIA: Rodinia = new Rodinia();
+
+class Rosetta extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "Rosetta",
+            NOSIZES,
+            "benchmarks/Rosetta/",
+            {
+                "3d-rendering": {
+                    standard: "c++11",
+                    topFunction: "rendering_sw",
+                    canonicalName: "3d-rendering",
+                    amalgamate: true,
+                    invalidInputSizes: []
+                },
+                "digit-recognition": {
+                    standard: "c++11",
+                    topFunction: "DigitRec_sw",
+                    canonicalName: "digit-recognition",
+                    amalgamate: true,
+                    invalidInputSizes: []
+                },
+                "face-detection": {
+                    standard: "c++11",
+                    topFunction: "face_detect_sw",
+                    canonicalName: "face-detection",
+                    amalgamate: true,
+                    invalidInputSizes: []
+                },
+                "optical-flow": {
+                    standard: "c++11",
+                    topFunction: "optical_flow_sw",
+                    canonicalName: "optical-flow",
+                    amalgamate: true,
+                    invalidInputSizes: []
+                },
+                "spam-filter": {
+                    standard: "c++11",
+                    topFunction: "SgdLR_sw",
+                    canonicalName: "spam-filter",
+                    altTopFunction: "main",
+                    amalgamate: true,
+                    invalidInputSizes: []
+                }
+            },
+            ["-D SW"]
+        );
+    }
+};
+
+export const ROSETTA: Rosetta = new Rosetta();
+
+class Spec2017 extends BenchmarkSuite<NOSIZES> {
+    public constructor() {
+        super(
+            "SPEC2017",
+            NOSIZES,
+            "benchmarks/SPEC2017/",
+            {
+                "519_lbm_r": { standard: "c11", topFunction: "main", canonicalName: "519.lbm_r", invalidInputSizes: [] },
+                "531_deepsjeng_r": { standard: "c++11", topFunction: "main", canonicalName: "531.deepsjeng_r", invalidInputSizes: [] }
+            },
+            ["-lm"]
+        );
+    }
+};
+
+export const SPEC2017: Spec2017 = new Spec2017();
+
+export enum POLYBENCH_SIZES {
+    MINI = "-DMINI_DATASET",
+    SMALL = "-DSMALL_DATASET",
+    MEDIUM = "-DMEDIUM_DATASET",
+    LARGE = "-DLARGE_DATASET",
+    EXTRALARGE = "-DEXTRALARGE_DATASET"
 }
 
-export const POLYBENCH_4_2_MEDIUM: BenchmarkSuite = {
-    name: "POLYBENCH4.2",
-    path: "benchmarks/Polybench/4.2/",
-    apps: {
-        "2mm": {
-            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
-        },
-        "3mm": {
-            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
-        },
-        "adi": {
-            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
-        },
-        "atax": {
-            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
-        },
-        "bicg": {
-            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
-        },
-        "cholesky": {
-            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
-        },
-        "correlation": {
-            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
-        },
-        "covariance": {
-            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
-        },
-        "deriche": {
-            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
-        },
-        "doitgen": {
-            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
-        },
-        "durbin": {
-            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
-        },
-        "gemm": {
-            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
-        },
-        "gemver": {
-            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
-        },
-        "gesummv": {
-            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
-        },
-        "gramschmidt": {
-            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
-        },
-        "heat_3d": {
-            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_1d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
-        },
-        "lu": {
-            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
-        },
-        "ludcmp": {
-            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
-        },
-        "mvt": {
-            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
-        },
-        "seidel_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
-        },
-        "symm": {
-            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
-        },
-        "syr2k": {
-            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
-        },
-        "syrk": {
-            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
-        },
-        "trisolv": {
-            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
-        },
-        "trmm": {
-            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
-        }
-    },
-    flags: ["-lm", "-DPOLYBENCH_TIME", "-DMEDIUM_DATASET"]
+class PolyBench_4_2 extends BenchmarkSuite<POLYBENCH_SIZES> {
+    public constructor() {
+        super(
+            "POLYBENCH4.2",
+            POLYBENCH_SIZES,
+            "benchmarks/Polybench/4.2/",
+            {
+                "2mm": {
+                    standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "3mm": {
+                    standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "adi": {
+                    standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "atax": {
+                    standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "bicg": {
+                    standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "cholesky": {
+                    standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "correlation": {
+                    standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "covariance": {
+                    standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "deriche": {
+                    standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "doitgen": {
+                    standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "durbin": {
+                    standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "gemm": {
+                    standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "gemver": {
+                    standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "gesummv": {
+                    standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "gramschmidt": {
+                    standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "heat-3d": {
+                    standard: "c11", topFunction: "main", canonicalName: "heat-3d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "jacobi-1d": {
+                    standard: "c11", topFunction: "main", canonicalName: "jacobi-1d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "jacobi-2d": {
+                    standard: "c11", topFunction: "main", canonicalName: "jacobi-2d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "lu": {
+                    standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "ludcmp": {
+                    standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "mvt": {
+                    standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "seidel-2d": {
+                    standard: "c11", topFunction: "main", canonicalName: "seidel-2d", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "symm": {
+                    standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "syr2k": {
+                    standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "syrk": {
+                    standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "trisolv": {
+                    standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                },
+                "trmm": {
+                    standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"], invalidInputSizes: []
+                }
+            },
+            ["-lm", "-DPOLYBENCH_TIME"]
+        );
+    }
 }
 
-export const POLYBENCH_4_2_LARGE: BenchmarkSuite = {
-    name: "POLYBENCH4.2",
-    path: "benchmarks/Polybench/4.2/",
-    apps: {
-        "2mm": {
-            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
-        },
-        "3mm": {
-            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
-        },
-        "adi": {
-            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
-        },
-        "atax": {
-            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
-        },
-        "bicg": {
-            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
-        },
-        "cholesky": {
-            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
-        },
-        "correlation": {
-            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
-        },
-        "covariance": {
-            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
-        },
-        "deriche": {
-            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
-        },
-        "doitgen": {
-            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
-        },
-        "durbin": {
-            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
-        },
-        "gemm": {
-            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
-        },
-        "gemver": {
-            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
-        },
-        "gesummv": {
-            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
-        },
-        "gramschmidt": {
-            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
-        },
-        "heat_3d": {
-            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_1d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
-        },
-        "lu": {
-            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
-        },
-        "ludcmp": {
-            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
-        },
-        "mvt": {
-            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
-        },
-        "seidel_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
-        },
-        "symm": {
-            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
-        },
-        "syr2k": {
-            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
-        },
-        "syrk": {
-            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
-        },
-        "trisolv": {
-            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
-        },
-        "trmm": {
-            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
-        }
-    },
-    flags: ["-lm", "-DPOLYBENCH_TIME", "-DLARGE_DATASET"]
-}
-
-export const POLYBENCH_4_2_EXTRALARGE: BenchmarkSuite = {
-    name: "POLYBENCH4.2",
-    path: "benchmarks/Polybench/4.2/",
-    apps: {
-        "2mm": {
-            standard: "c11", topFunction: "main", canonicalName: "2mm", extraSourceFiles: ["../polybench"]
-        },
-        "3mm": {
-            standard: "c11", topFunction: "main", canonicalName: "3mm", extraSourceFiles: ["../polybench"]
-        },
-        "adi": {
-            standard: "c11", topFunction: "main", canonicalName: "adi", extraSourceFiles: ["../polybench"]
-        },
-        "atax": {
-            standard: "c11", topFunction: "main", canonicalName: "atax", extraSourceFiles: ["../polybench"]
-        },
-        "bicg": {
-            standard: "c11", topFunction: "main", canonicalName: "bicg", extraSourceFiles: ["../polybench"]
-        },
-        "cholesky": {
-            standard: "c11", topFunction: "main", canonicalName: "cholesky", extraSourceFiles: ["../polybench"]
-        },
-        "correlation": {
-            standard: "c11", topFunction: "main", canonicalName: "correlation", extraSourceFiles: ["../polybench"]
-        },
-        "covariance": {
-            standard: "c11", topFunction: "main", canonicalName: "covariance", extraSourceFiles: ["../polybench"]
-        },
-        "deriche": {
-            standard: "c11", topFunction: "main", canonicalName: "deriche", extraSourceFiles: ["../polybench"]
-        },
-        "doitgen": {
-            standard: "c11", topFunction: "main", canonicalName: "doitgen", extraSourceFiles: ["../polybench"]
-        },
-        "durbin": {
-            standard: "c11", topFunction: "main", canonicalName: "durbin", extraSourceFiles: ["../polybench"]
-        },
-        "gemm": {
-            standard: "c11", topFunction: "main", canonicalName: "gemm", extraSourceFiles: ["../polybench"]
-        },
-        "gemver": {
-            standard: "c11", topFunction: "main", canonicalName: "gemver", extraSourceFiles: ["../polybench"]
-        },
-        "gesummv": {
-            standard: "c11", topFunction: "main", canonicalName: "gesummv", extraSourceFiles: ["../polybench"]
-        },
-        "gramschmidt": {
-            standard: "c11", topFunction: "main", canonicalName: "gramschmidt", extraSourceFiles: ["../polybench"]
-        },
-        "heat_3d": {
-            standard: "c11", topFunction: "main", canonicalName: "heat_3d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_1d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_1d", extraSourceFiles: ["../polybench"]
-        },
-        "jacobi_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "jacobi_2d", extraSourceFiles: ["../polybench"]
-        },
-        "lu": {
-            standard: "c11", topFunction: "main", canonicalName: "lu", extraSourceFiles: ["../polybench"]
-        },
-        "ludcmp": {
-            standard: "c11", topFunction: "main", canonicalName: "ludcmp", extraSourceFiles: ["../polybench"]
-        },
-        "mvt": {
-            standard: "c11", topFunction: "main", canonicalName: "mvt", extraSourceFiles: ["../polybench"]
-        },
-        "seidel_2d": {
-            standard: "c11", topFunction: "main", canonicalName: "seidel_2d", extraSourceFiles: ["../polybench"]
-        },
-        "symm": {
-            standard: "c11", topFunction: "main", canonicalName: "symm", extraSourceFiles: ["../polybench"]
-        },
-        "syr2k": {
-            standard: "c11", topFunction: "main", canonicalName: "syr2k", extraSourceFiles: ["../polybench"]
-        },
-        "syrk": {
-            standard: "c11", topFunction: "main", canonicalName: "syrk", extraSourceFiles: ["../polybench"]
-        },
-        "trisolv": {
-            standard: "c11", topFunction: "main", canonicalName: "trisolv", extraSourceFiles: ["../polybench"]
-        },
-        "trmm": {
-            standard: "c11", topFunction: "main", canonicalName: "trmm", extraSourceFiles: ["../polybench"]
-        }
-    },
-    flags: ["-lm", "-DPOLYBENCH_TIME", "-DEXTRALARGE_DATASET"]
-}
+export const POLYBENCH_4_2: PolyBench_4_2 = new PolyBench_4_2();

--- a/src/LiteBenchmarkLoader.ts
+++ b/src/LiteBenchmarkLoader.ts
@@ -25,7 +25,8 @@ export type AppSummary = {
     altTopFunction?: string
     amalgamate?: boolean,
     extraFlags?: string[],
-    extraFiles?: string[]
+    extraFiles?: string[],
+    extraSourceFiles?: string[],
 }
 
 export type LoadResult = {
@@ -88,6 +89,21 @@ export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPat
     const [sources, absoluteNonSources, absoluteSubdirs] = readSourcesInFolder(fullPath);
     log(`Found ${sources.length} files for ${appSummary.canonicalName}`);
 
+    let extraSources: string[] = [];
+    for (let extraSource of (appSummary.extraSourceFiles ?? [])) {
+        extraSource = path.join(fullPath, extraSource);
+        if (Io.isFile(extraSource)) {
+            extraSources.push(extraSource);
+            continue;
+        }
+        
+        if (Io.isFolder(extraSource)) {
+            const [nestedExtraSources, _, __] = readSourcesInFolder(extraSource);
+            extraSources.push(...nestedExtraSources);
+        }
+    }
+    log(`Found ${extraSources.length} extra source files for ${appSummary.canonicalName}`);
+
     if (absoluteNonSources.length > 0) {
         log(`Found ${absoluteNonSources.length} non-source files for ${appSummary.canonicalName}`);
     }
@@ -126,9 +142,14 @@ export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPat
     let keepTrying = true;
     do {
         Clava.pushAst(ClavaJoinPoints.program());
+        for (const extraSource of extraSources) {
+            Clava.addExistingFile(extraSource);
+        }
+
         for (const source of sources) {
             Clava.addExistingFile(source);
         }
+        
         keepTrying = Clava.rebuild();
 
         if (!keepTrying) {

--- a/src/LiteBenchmarkLoader.ts
+++ b/src/LiteBenchmarkLoader.ts
@@ -11,46 +11,79 @@ import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync } from "fs"
 import path, { basename, join } from "path";
 import { fileURLToPath } from "url";
 
-export type BenchmarkSuite = {
-    name: string,
-    path: string,
-    apps: { [key: string]: AppSummary },
-    flags: string[],
+export abstract class BenchmarkSuite<InputSize extends string> {
+    public name: string;
+    public path: string;
+    public apps: { [key: string]: AppSummary<InputSize> };
+    public flags: string[];
+    public enumObject: { [k: string]: InputSize };
+
+    protected constructor(name: string, enumObject: { [k: string]: InputSize }, path: string, apps: { [key: string]: AppSummary<InputSize> }, flags: string[]) {
+        this.name = name;
+        this.path = path;
+        this.apps = apps;
+        this.flags = flags;
+        this.enumObject = enumObject;
+    }
 };
 
-export type AppSummary = {
+export type AppSummary<InputSizes> = {
     canonicalName: string,
     standard: string,
     topFunction: string,
     altTopFunction?: string
     amalgamate?: boolean,
+    invalidInputSizes: InputSizes[],
     extraFlags?: string[],
     extraFiles?: string[],
     extraSourceFiles?: string[],
 }
 
-export type LoadResult = {
+export type LoadResult<InputSize extends string> = {
     success: boolean,
-    appSummary: AppSummary,
+    appSummary: AppSummary<InputSize>,
     absoluteDirents?: string[],
     relativeDirents?: string[],
     appRoot?: string
 }
 
-export function appList(suite: BenchmarkSuite): string[] {
+export function appList<InputSize extends string>(suite: BenchmarkSuite<InputSize>): string[] {
     return Object.keys(suite.apps);
 }
 
-export function* loadSuite(suite: BenchmarkSuite, overridePath?: string): Generator<LoadResult> {
-    for (const app of appList(suite)) {
-        log(`Loading app: ${app}`);
+export function* loadSuite<InputSize extends string>(suite: BenchmarkSuite<InputSize>, overridePath?: string, ...inputSizes: InputSize[]): Generator<LoadResult<InputSize>> {
+    inputSizes = inputSizes.length === 0 ? Object.values(suite.enumObject) : inputSizes;
 
-        const res = loadApp(suite, suite.apps[app], overridePath ? overridePath : undefined);
-        yield res;
+    for (const inputSize of inputSizes) {
+        log(`Loading apps for input size «${Object.keys(suite.enumObject).find(
+            key => suite.enumObject[key] === inputSize
+        )}»`);
+
+        for (const appName of appList(suite)) {
+            if (suite.apps[appName].invalidInputSizes.includes(inputSize)) {
+                log(`Skipping app «${appName}» since the current input size isn't supported`);
+                continue;
+            }
+            log(`Loading app: ${appName}`);
+
+            const res = loadApp(suite, suite.apps[appName], overridePath ? overridePath : undefined, inputSize);
+            yield res;
+        }
     }
+
+    if (inputSizes.length === 0) {
+        for (const appName of appList(suite)) {
+            log(`Loading app: ${appName}`);
+
+            const res = loadApp(suite, suite.apps[appName], overridePath ? overridePath : undefined);
+            yield res;
+        }
+    }
+
+
 }
 
-export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPath?: string): LoadResult {
+export function loadApp<InputSize extends string>(suite: BenchmarkSuite<InputSize>, appSummary: AppSummary<InputSize>, cachedPath?: string, inputSize?: InputSize): LoadResult<InputSize> {
     const fullPath = cachedPath != undefined ? cachedPath : (() => {
         const __filename = fileURLToPath(import.meta.url);
         const __dirname = path.dirname(__filename);
@@ -64,6 +97,10 @@ export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPat
     const flags = [...suite.flags];
     if (appSummary.extraFlags) {
         flags.push(...appSummary.extraFlags);
+    }
+
+    if (inputSize !== undefined) {
+        flags.push(inputSize);
     }
 
     if (suite.flags.length > 0) {
@@ -96,7 +133,7 @@ export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPat
             extraSources.push(extraSource);
             continue;
         }
-        
+
         if (Io.isFolder(extraSource)) {
             const [nestedExtraSources, _, __] = readSourcesInFolder(extraSource);
             extraSources.push(...nestedExtraSources);
@@ -149,7 +186,7 @@ export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPat
         for (const source of sources) {
             Clava.addExistingFile(source);
         }
-        
+
         keepTrying = Clava.rebuild();
 
         if (!keepTrying) {
@@ -163,7 +200,7 @@ export function loadApp(suite: BenchmarkSuite, appSummary: AppSummary, cachedPat
 
     transformApp(appSummary);
 
-    const res: LoadResult = {
+    const res: LoadResult<InputSize> = {
         success: keepTrying,
         appSummary: appSummary,
         absoluteDirents: [...absoluteNonSources, ...absoluteSubdirs],
@@ -224,7 +261,7 @@ export function copyDirentsRelative(dirents: string[], originalPath: string, tar
     }
 }
 
-function transformApp(appSummary: AppSummary): boolean {
+function transformApp<InputSize extends string>(appSummary: AppSummary<InputSize>): boolean {
     try {
         if (appSummary.amalgamate) {
             const amalgamator = new Amalgamator();

--- a/src/SuiteRunner.ts
+++ b/src/SuiteRunner.ts
@@ -10,7 +10,7 @@ export abstract class SuiteRunner {
         this.lineLength = lineLength;
     }
 
-    public runScriptForSuite(suite: BenchmarkSuite, apps: string[], config: Record<string, any>, disableCaching: boolean = true): boolean {
+    public runScriptForSuite<InputSize extends string>(suite: BenchmarkSuite<InputSize>, apps: string[], config: Record<string, any>, disableCaching: boolean = true): boolean {
         for (const app of apps) {
             this.log(`Running ${this.getScriptName()} for app ${app} of benchmark suite ${suite.name}`);
             const cachedPath = `${config.outputDir}/${app}/src/trans`;
@@ -21,7 +21,7 @@ export abstract class SuiteRunner {
             }
 
             let invalidCache = false;
-            let res: LoadResult;
+            let res: LoadResult<InputSize>;
 
             if (disableCaching) {
                 this.log(`Caching is disabled, loading original version of ${app}...`);

--- a/test/TestLoadCortexSuiteVision.ts
+++ b/test/TestLoadCortexSuiteVision.ts
@@ -1,10 +1,10 @@
 import { copyDirentsRelative, loadApp, LoadResult, loadSuite } from "../src/LiteBenchmarkLoader.js";
-import { CORTEXSUITE_VISION } from "../src/BenchmarkSuites.js";
+import { CORTEXSUITE_VISION, NOSIZES  } from "../src/BenchmarkSuites.js";
 import { FileJp } from "@specs-feup/clava/api/Joinpoints.js";
 import Query from "@specs-feup/lara/api/weaver/Query.js";
 import Clava from "@specs-feup/clava/api/clava/Clava.js";
 
-function handleApp(res: LoadResult): void {
+function handleApp(res: LoadResult<NOSIZES>): void {
     const name = res.appSummary.canonicalName;
 
     for (const file of Query.search(FileJp)) {

--- a/test/TestLoadPolybench.ts
+++ b/test/TestLoadPolybench.ts
@@ -1,0 +1,24 @@
+import { FunctionJp } from "@specs-feup/clava/api/Joinpoints.js";
+import Query from "@specs-feup/lara/api/weaver/Query.js";
+import { POLYBENCH_4_2_MEDIUM } from "../src/BenchmarkSuites.js";
+import { copyDirentsAbsolute, loadSuite } from "../src/LiteBenchmarkLoader.js";
+import Clava from "@specs-feup/clava/api/clava/Clava.js";
+
+
+for (const res of loadSuite(POLYBENCH_4_2_MEDIUM)) {
+    const name = res.appSummary.canonicalName;
+
+    if (res.success) {
+        console.log(`Loaded app: ${name}, top function: ${res.appSummary.topFunction}`);
+
+        for (const fun of Query.search(FunctionJp)) {
+            console.log(fun.name);
+        }
+
+        Clava.writeCode(`dist/Polybench4_2/${name}`);
+        copyDirentsAbsolute(res.absoluteDirents!, `dist/Polybench4_2/${name}`);
+    }
+    else {
+        console.log(`Failed to load app: ${name}`);
+    }
+}

--- a/test/TestLoadPolybench.ts
+++ b/test/TestLoadPolybench.ts
@@ -5,7 +5,7 @@ import { copyDirentsAbsolute, loadSuite } from "../src/LiteBenchmarkLoader.js";
 import Clava from "@specs-feup/clava/api/clava/Clava.js";
 
 
-for (const res of loadSuite(POLYBENCH_4_2, undefined, POLYBENCH_SIZES.MEDIUM, POLYBENCH_SIZES.LARGE)) {
+for (const res of loadSuite(POLYBENCH_4_2, undefined, POLYBENCH_SIZES.SMALL)) {
     const name = res.appSummary.canonicalName;
 
     if (res.success) {

--- a/test/TestLoadPolybench.ts
+++ b/test/TestLoadPolybench.ts
@@ -1,11 +1,11 @@
 import { FunctionJp } from "@specs-feup/clava/api/Joinpoints.js";
 import Query from "@specs-feup/lara/api/weaver/Query.js";
-import { POLYBENCH_4_2_MEDIUM } from "../src/BenchmarkSuites.js";
+import { POLYBENCH_4_2, POLYBENCH_SIZES } from "../src/BenchmarkSuites.js";
 import { copyDirentsAbsolute, loadSuite } from "../src/LiteBenchmarkLoader.js";
 import Clava from "@specs-feup/clava/api/clava/Clava.js";
 
 
-for (const res of loadSuite(POLYBENCH_4_2_MEDIUM)) {
+for (const res of loadSuite(POLYBENCH_4_2, undefined, POLYBENCH_SIZES.MEDIUM, POLYBENCH_SIZES.LARGE)) {
     const name = res.appSummary.canonicalName;
 
     if (res.success) {


### PR DESCRIPTION
This branch contains support for both polybench 4.2 and dataset sizes.
The former has been added in the likeness of all other benchmarks, though I did have to also add support for additional source files to avoid duplication.

The way the BenchmarkSuites are defined has been refactored. Now, every BenchmarkSuite has a class of its own, extending a base generic BenchmarkSuite class. It must be parameterized with an enum describing which possible sizes it allows. If one of the suite's apps doesn't allow one of the input sizes, it must declare so in the "invalidInputSizes" array at its declaration. Naturally, this means that AppSummary also has to be parameterized.
The loadSuite and loadApp have also been extended to accommodate these features, though they have been done so in a backwards compatible way. If the user does not specify which input sizes to use, loadSuite iterates over all possible sizes. If loadApp doesn't receive an input size then it assumes there is none, and therefore adds no flags.

However, it seems I cannot compile many of the test suites, with errors such as:
```
/tmp/clang_ast_exe/clang_includes/1-libcxx_12.0.0/cstddef:44:15: fatal error: 'stddef.h' file not found
#include_next <stddef.h>
              ^~~~~~~~~~
1 error generated.
Error while processing /tmp/__clava_woven_8c03eb3f-0f97-4af2-b234-65d0af436cce/utils.h.
```

In this case, I was attempting to test the Rosetta-Single suite. I do not currently have the time to fix these issues, so further testing is still needed.

Additionally, the sizes for cortexsuite-vision still need to be added.

 